### PR TITLE
Migrating from the read-only Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This plugin integrates with an [Anka Build Cloud](https://ankadocs.veertu.com/do
 ### Prerequisites
 
 1. [Anka Build Cloud (Controller & Registry + Nodes)](https://ankadocs.veertu.com/docs/anka-build-cloud/overview/)
-2. [VM Templates and Tags with your project dependencies](https://ankadocs.veertu.com/docs/getting-started/creating-your-first-vm/)
+2. [VM Template and Tag with your project dependencies](https://ankadocs.veertu.com/docs/getting-started/creating-your-first-vm/)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# jenkins-anka-ci
+# Anka Build Plugin
+
+> Usage of the plugin is detailed on our [Official Documentation](https://ankadocs.veertu.com/docs/anka-build-cloud/ci-plugins/jenkins/)
+
+This plugin integrates with an [Anka Build Cloud](https://ankadocs.veertu.com/docs/anka-build-cloud/) and allows on-demand provisioning of Anka VMs for your pipeline jobs.
+
+### Prerequisites
+
+1. [Anka Build Cloud (Controller & Registry + Nodes)](https://ankadocs.veertu.com/docs/anka-build-cloud/overview/)
+2. [VM Templates and Tags with your project dependencies](https://ankadocs.veertu.com/docs/getting-started/creating-your-first-vm/)

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <name>Anka Plugin</name>
   <description>Integrates Jenkins with Anka</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Veertu+Plugin</url>
+  <url>https://github.com/jenkinsci/anka-build-plugin</url>
 
   <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
 


### PR DESCRIPTION
> The Jenkins wiki was made 'read-only' in October 2019. Plugin documentation should be maintained in the GitHub repository of the plugin. See the plugin documentation guidelines for details.

This PR updates the README.md  and pom.xml with new information and allows me to then submit the Jenkins.io JIRA ticket for them to switch our plugin to using github's README.md.