### PR TITLE
Fix for Issue #43: Plugin sends 2 consecutive/duplicate termination requests

### DIFF
--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -729,9 +729,7 @@ public class AnkaMgmtCloud extends Cloud {
             return;
         }
 
-        boolean terminationAccepted = ankaAPI.terminateInstance(id);
-
-        if (terminationAccepted) {
+        if (ankaAPI.terminateInstance(id)) {
             Log("Termination request for VM instance " + id + " accepted");
         } else {
             Log("Termination request for VM instance " + id + " was not accepted");

--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -729,30 +729,14 @@ public class AnkaMgmtCloud extends Cloud {
             return;
         }
 
-        ankaAPI.terminateInstance(id);
+        boolean terminationAccepted = ankaAPI.terminateInstance(id);
 
-        long startTime = System.currentTimeMillis();
-        long timeoutMs = 60_000;
-
-        while (System.currentTimeMillis() - startTime < timeoutMs) {
-            ankaVmInstance = ankaAPI.showInstance(id);
-
-            if (ankaVmInstance == null || ankaVmInstance.isTerminatingOrTerminated()) {
-                Log("VM instance " + id + " terminated successfully");
-                return;
-            }
-
-            try {
-                sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                Log("Thread was interrupted while waiting for instance termination");
-                throw new AnkaMgmtException("Thread was interrupted while waiting for instance termination");
-            }
+        if (terminationAccepted) {
+            Log("Termination request for VM instance " + id + " accepted");
+        } else {
+            Log("Termination request for VM instance " + id + " was not accepted");
+            throw new AnkaMgmtException("Failed to terminate VM instance " + id);
         }
-
-        Log("Failed to terminate VM instance " + id + " within timeout period");
-        throw new AnkaMgmtException("Failed to terminate VM instance " + id + " within timeout period");
     }
 
     public AnkaVmInstance showInstance(String id) throws AnkaMgmtException {


### PR DESCRIPTION
## Pull Request 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other: (describe here) 
  
## Proposed Change
<!-- Explain your change, its motivation, compare previous and new behaviour and link to issue, if exists -->
Issue Number: #43 

<!-- Write your answer here -->
This PR fixes an issue where the plugin was calling `terminateInstance` multiple times unnecessarily.

- Remove duplicate termination requests.
- Add a timeout loop to wait for the VM to shut down.
- Handle thread interruption properly and throws an exception if the VM doesn’t terminate in time.

## Breaking Change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications here -->

## Checklist

Please validate that your PR fulfills the following requirements:
- [X] I have read the **CONTRIBUTING.md** documentation
- [X] I have branched from the master branch
- [X] I have checked that a similar PR does not exist or has been rejected in the past
- [X] PR changes are specific to a feature or bug
- [X] No style/format/cosmetic changes included
- [X] I have used existing style and naming patterns in my changes
- [ ] Tests for the changes have been added/updated (if relevant)
- [ ] Built/compiled and tested locally
- [ ] Docs have been added/updated (if relevant)
- [ ] I have squashed my changes into a single commit


## Additional Information
<!-- Any other information that is important to this PR such as screenshots of how the feature/bug looked before and after the change. -->