### PR TITLE
release/v2.14.0

### DIFF
--- a/.github/workflows/pr-maven-tests.yml
+++ b/.github/workflows/pr-maven-tests.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/pr-maven-tests.yml
+++ b/.github/workflows/pr-maven-tests.yml
@@ -1,0 +1,27 @@
+name: PR Maven Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run Maven tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run test suite
+        run: mvn -Daether.remoteRepositoryFilter.prefixes=false test

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,12 @@
 *.DS_Store
 *.iml
 work*
+!.github/workflows/
+!.github/workflows/*.yml
 lib*
 target*
 .m2
 docker/jenkins/
 docker/squid/
+.mvn-debug.log
+.m2-local

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Anka Build Plugin
+# Anka Jenkins Build Plugin
+
+[![PR Maven Tests](https://github.com/jenkinsci/anka-build-plugin/actions/workflows/pr-maven-tests.yml/badge.svg)](https://github.com/jenkinsci/anka-build-plugin/actions/workflows/pr-maven-tests.yml)
 
 Usage of this plugin is detailed on our [Official Documentation](https://docs.veertu.com/anka/plugins-and-integrations/controller-+-registry/jenkins/).
 
@@ -12,7 +14,33 @@ Contributors are welcome! Please submit an Issue or PR.
 
 ### Build
 
-See `build-macos.bash` for building the plugin.
+Build locally with Maven:
+
+```bash
+mvn -Daether.remoteRepositoryFilter.prefixes=false clean package
+```
+
+If you use Maven 3, you can usually omit `-Daether.remoteRepositoryFilter.prefixes=false`.
+
+Or, alternatively, build in Docker:
+
+```bash
+./build-docker.bash
+```
+
+### Test
+
+Run all tests:
+
+```bash
+mvn -Daether.remoteRepositoryFilter.prefixes=false test
+```
+
+Run a single test class:
+
+```bash
+mvn -Daether.remoteRepositoryFilter.prefixes=false -Dtest=ConfigurationAsCodeTest test
+```
 
 ## Release
 

--- a/_ci/Jenkinsfile
+++ b/_ci/Jenkinsfile
@@ -19,7 +19,17 @@ pipeline {
     } }
     stages {
         stage('Build Plugin') { steps {
-            sh 'mvn package'
+            sh '''
+                # Override Plugin-Version's snapshot suffix so the Jenkins
+                # plugins page shows when this snapshot was built and which
+                # commit it came from, e.g.
+                #   Version 2.14.0-SNAPSHOT (built-20260422.2122-2f59a88d)
+                PLUGIN_BUILD_TIMESTAMP_UTC=$(date -u +%Y%m%d.%H%M)
+                PLUGIN_GIT_SHORT_SHA=$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)
+                PLUGIN_VERSION_DESCRIPTION="built-${PLUGIN_BUILD_TIMESTAMP_UTC}-${PLUGIN_GIT_SHORT_SHA}"
+                echo "[Jenkinsfile] plugin.version.description: ${PLUGIN_VERSION_DESCRIPTION}"
+                mvn -Dplugin.version.description="${PLUGIN_VERSION_DESCRIPTION}" package
+            '''
         } }
         stage('Archive') { steps {
             archiveArtifacts artifacts: '**/target/anka-build.hpi', onlyIfSuccessful: true

--- a/build-docker.bash
+++ b/build-docker.bash
@@ -6,6 +6,18 @@ cd "${SCRIPT_DIR}/_ci"
 docker build --no-cache -t anka-build-plugin --load .
 cd "${SCRIPT_DIR}"
 
+# Jenkins' "Manage Plugins" page shows Plugin-Version verbatim from the HPI's
+# MANIFEST.MF. When the project is a -SNAPSHOT, maven-hpi-plugin appends
+# "(<plugin.version.description>)" to Plugin-Version. By default that's
+# "private-<short-git-sha>-<user>", which doesn't tell you WHEN the snapshot
+# was built. Override it with a UTC build timestamp + short git sha so the
+# Jenkins UI shows e.g.:
+#   Version 2.14.0-SNAPSHOT (built-20260422.2122-2f59a88d)
+PLUGIN_BUILD_TIMESTAMP_UTC="$(date -u +%Y%m%d.%H%M)"
+PLUGIN_GIT_SHORT_SHA="$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)"
+PLUGIN_VERSION_DESCRIPTION="built-${PLUGIN_BUILD_TIMESTAMP_UTC}-${PLUGIN_GIT_SHORT_SHA}"
+echo "[build-docker] plugin.version.description: ${PLUGIN_VERSION_DESCRIPTION}"
+
 # Optional extra Maven arguments (host env), e.g. MVN_EXTRA_ARGS="-DskipTests"
 docker run \
   --rm \
@@ -14,5 +26,6 @@ docker run \
   -v "${HOME}/.mvn:/root/.mvn" \
   -v "${HOME}/.m2:/root/.m2" \
   -e MVN_EXTRA_ARGS="${MVN_EXTRA_ARGS:-}" \
+  -e PLUGIN_VERSION_DESCRIPTION="${PLUGIN_VERSION_DESCRIPTION}" \
   anka-build-plugin \
-  /bin/bash -c 'cd /root/anka-build-plugin && mvn -Daether.remoteRepositoryFilter.prefixes=false clean package ${MVN_EXTRA_ARGS}'
+  /bin/bash -c 'cd /root/anka-build-plugin && mvn -Daether.remoteRepositoryFilter.prefixes=false -Dplugin.version.description="${PLUGIN_VERSION_DESCRIPTION}" clean package ${MVN_EXTRA_ARGS}'

--- a/build-docker.bash
+++ b/build-docker.bash
@@ -2,7 +2,7 @@
 set -exo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $SCRIPT_DIR/_ci
-docker build --no-cache -t anka-build-plugin .
+docker build --no-cache -t anka-build-plugin --load .
 cd $SCRIPT_DIR
 docker run \
 --rm --name anka-build-plugin -it \

--- a/build-docker.bash
+++ b/build-docker.bash
@@ -1,12 +1,18 @@
 #!/bin/bash
-set -exo pipefail
+set -euo pipefail
+
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-cd $SCRIPT_DIR/_ci
+cd "${SCRIPT_DIR}/_ci"
 docker build --no-cache -t anka-build-plugin --load .
-cd $SCRIPT_DIR
+cd "${SCRIPT_DIR}"
+
+# Optional extra Maven arguments (host env), e.g. MVN_EXTRA_ARGS="-DskipTests"
 docker run \
---rm --name anka-build-plugin -it \
--v ${SCRIPT_DIR}:/root/anka-build-plugin \
--v ${HOME}/.mvn:/root/.mvn \
--v ${HOME}/.m2:/root/.m2 \
-anka-build-plugin /bin/bash -c "cd /root/anka-build-plugin && mvn clean && mvn package"
+  --rm \
+  --name anka-build-plugin \
+  -v "${SCRIPT_DIR}:/root/anka-build-plugin" \
+  -v "${HOME}/.mvn:/root/.mvn" \
+  -v "${HOME}/.m2:/root/.m2" \
+  -e MVN_EXTRA_ARGS="${MVN_EXTRA_ARGS:-}" \
+  anka-build-plugin \
+  /bin/bash -c 'cd /root/anka-build-plugin && mvn -Daether.remoteRepositoryFilter.prefixes=false clean package ${MVN_EXTRA_ARGS}'

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <relativePath />
     </parent>
     <artifactId>anka-build</artifactId>
-    <version>2.13.2-SNAPSHOT</version>
+    <version>2.14.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <properties>

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaAPI.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaAPI.java
@@ -90,7 +90,7 @@ public class AnkaAPI {
     }
 
     public boolean terminateInstance(String vmId) throws AnkaMgmtException {
-        LOGGER.info("Sending termination request to instance: " + vmId);
+        LOGGER.info(AnkaSdkLog.prefix("Sending termination request to instance: " + vmId));
         boolean result = communicator.terminateVm(vmId);
         invalidateCache();
         return result;

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaSdkLog.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaSdkLog.java
@@ -1,0 +1,15 @@
+package com.veertu.ankaMgmtSdk;
+
+final class AnkaSdkLog {
+    private static final String PREFIX = "[Anka] ";
+
+    private AnkaSdkLog() {
+    }
+
+    static String prefix(String message) {
+        if (message == null || message.startsWith(PREFIX)) {
+            return message;
+        }
+        return PREFIX + message;
+    }
+}

--- a/src/main/java/com/veertu/ankaMgmtSdk/ConcAnkaMgmtVm.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/ConcAnkaMgmtVm.java
@@ -28,7 +28,7 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
         this.sessionId = sessionId;
         this.sshConnectionPort = sshConnectionPort;
         this.terminated = false;
-        logger.info(String.format("init VM %s", sessionId));
+        logger.info(AnkaSdkLog.prefix(String.format("init VM %s", sessionId)));
     }
 
     public String getStatus() throws AnkaMgmtException {
@@ -72,7 +72,7 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
                 if (session != null) {
                     this.cachedVmSession = session;
                 } else {
-                    logger.info("info for vm is null");
+                    logger.info(AnkaSdkLog.prefix("info for vm is null"));
                 }
             }
             return this.cachedVmSession;
@@ -152,14 +152,14 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
     }
 
     public String waitForBoot(int schedulingTimeout) throws InterruptedException, IOException, AnkaMgmtException {
-        logger.info(String.format("waiting for vm %s to boot", this.sessionId));
+        logger.info(AnkaSdkLog.prefix(String.format("waiting for vm %s to boot", this.sessionId)));
         int timeWaited = 0;
 
         while (isScheduling()) {
             // terminate if scheduling timeout is reached
             Thread.sleep(waitUnit);
             timeWaited += waitUnit;
-            logger.info(String.format("waiting for vm %s %d to stop scheduling", this.sessionId, timeWaited));
+            logger.info(AnkaSdkLog.prefix(String.format("waiting for vm %s %d to stop scheduling", this.sessionId, timeWaited)));
             if (timeWaited > schedulingTimeout * waitUnit) {
                 this.terminate();
                 throw new IOException("vm scheduling too long");
@@ -173,7 +173,7 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
             try {
                 Thread.sleep(waitUnit);
                 timeWaited += waitUnit;
-                logger.info(String.format("waiting for vm %s %d to boot", this.sessionId, timeWaited));
+                logger.info(AnkaSdkLog.prefix(String.format("waiting for vm %s %d to boot", this.sessionId, timeWaited)));
                 if (timeWaited > maxRunningTimeout) {
                     this.terminate();
                     throw new IOException("could not start vm");
@@ -181,7 +181,7 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
                 }
             } catch (InterruptedException e) {
                 if (isPulling()) {  // Don't let jenkins interrupt us while we are pulling
-                    logger.info(String.format("vm %s is pulling, ignoring InterruptedException", this.sessionId));
+                    logger.info(AnkaSdkLog.prefix(String.format("vm %s is pulling, ignoring InterruptedException", this.sessionId)));
                 } else {
                     throw e;
                 }
@@ -190,7 +190,7 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
 
         String ip;
         timeWaited = 0;
-        logger.info(String.format("waiting for vm %s to get an ip ", this.sessionId));
+        logger.info(AnkaSdkLog.prefix(String.format("waiting for vm %s to get an ip ", this.sessionId)));
         while (true) { // wait to get machine ip
 
             ip = this.getIp();
@@ -199,7 +199,7 @@ public class ConcAnkaMgmtVm implements AnkaMgmtVm {
 
             Thread.sleep(waitUnit);
             timeWaited += waitUnit;
-            logger.info(String.format("waiting for vm %s %d to get ip ", this.sessionId, timeWaited));
+            logger.info(AnkaSdkLog.prefix(String.format("waiting for vm %s %d to get ip ", this.sessionId, timeWaited)));
             if (timeWaited > maxIpTimeout) {
                 this.terminate();
                 throw new IOException("VM started but couldn't acquire ip");

--- a/src/main/java/com/veertu/plugin/anka/AbstractAnkaSlave.java
+++ b/src/main/java/com/veertu/plugin/anka/AbstractAnkaSlave.java
@@ -38,7 +38,6 @@ public abstract class AbstractAnkaSlave extends Slave {
     protected boolean taskExecuted;
     protected boolean saveImageSent;
     protected boolean hadProblemsInBuild = false;
-    protected boolean hadUnknownBuildOutcome = false;
 
     public String getJobNameAndNumber() {
         return jobNameAndNumber;
@@ -117,7 +116,7 @@ public abstract class AbstractAnkaSlave extends Slave {
                 LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1} is in state {2}"), new Object[]{getNodeName(), instanceId, vm.getSessionState()});
                 SaveImageParameters saveImageParams = template.getSaveImageParameters();
                 if (taskExecuted && saveImageParams != null && this.template.getSaveImageParameters().getSaveImage()
-                        && saveImageParams.getSaveImage() && !hadProblemsInBuild && !hadUnknownBuildOutcome) {
+                        && saveImageParams.getSaveImage() && !hadProblemsInBuild) {
                     LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1}, saving image"), new Object[]{getNodeName(), instanceId});
 
                     synchronized (this) {
@@ -200,10 +199,6 @@ public abstract class AbstractAnkaSlave extends Slave {
 
     public void setHadErrorsOnBuild(boolean value) {
         this.hadProblemsInBuild = value;
-    }
-
-    public void setHadUnknownBuildOutcome(boolean value) {
-        this.hadUnknownBuildOutcome = value;
     }
 
     public void setDescription(String jobAndNumber) {
@@ -305,7 +300,7 @@ public abstract class AbstractAnkaSlave extends Slave {
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         this.setTaskExecuted(true);
         SaveImageParameters saveImageParams = template.getSaveImageParameters();
-        if (!hadProblemsInBuild && !hadUnknownBuildOutcome && saveImageParams != null
+        if (!hadProblemsInBuild && saveImageParams != null
                 && this.template.getSaveImageParameters().getSaveImage() &&
                 saveImageParams.getSaveImage()) {
             AnkaMgmtCloud.markFuture(cloud, this);

--- a/src/main/java/com/veertu/plugin/anka/AbstractAnkaSlave.java
+++ b/src/main/java/com/veertu/plugin/anka/AbstractAnkaSlave.java
@@ -38,6 +38,7 @@ public abstract class AbstractAnkaSlave extends Slave {
     protected boolean taskExecuted;
     protected boolean saveImageSent;
     protected boolean hadProblemsInBuild = false;
+    protected boolean hadUnknownBuildOutcome = false;
 
     public String getJobNameAndNumber() {
         return jobNameAndNumber;
@@ -115,7 +116,8 @@ public abstract class AbstractAnkaSlave extends Slave {
             if (vm != null) {
                 LOGGER.log(Level.INFO, "Node {0} Instance {1} is in state {2}", new Object[]{getNodeName(), instanceId, vm.getSessionState()});
                 SaveImageParameters saveImageParams = template.getSaveImageParameters();
-                if (taskExecuted && saveImageParams != null && this.template.getSaveImageParameters().getSaveImage() && saveImageParams.getSaveImage() && !hadProblemsInBuild) {
+                if (taskExecuted && saveImageParams != null && this.template.getSaveImageParameters().getSaveImage()
+                        && saveImageParams.getSaveImage() && !hadProblemsInBuild && !hadUnknownBuildOutcome) {
                     LOGGER.log(Level.INFO, "Node {0} Instance {1}, saving image", new Object[]{getNodeName(), instanceId});
 
                     synchronized (this) {
@@ -198,6 +200,10 @@ public abstract class AbstractAnkaSlave extends Slave {
 
     public void setHadErrorsOnBuild(boolean value) {
         this.hadProblemsInBuild = value;
+    }
+
+    public void setHadUnknownBuildOutcome(boolean value) {
+        this.hadUnknownBuildOutcome = value;
     }
 
     public void setDescription(String jobAndNumber) {
@@ -299,7 +305,8 @@ public abstract class AbstractAnkaSlave extends Slave {
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         this.setTaskExecuted(true);
         SaveImageParameters saveImageParams = template.getSaveImageParameters();
-        if (!hadProblemsInBuild && saveImageParams != null && this.template.getSaveImageParameters().getSaveImage() &&
+        if (!hadProblemsInBuild && !hadUnknownBuildOutcome && saveImageParams != null
+                && this.template.getSaveImageParameters().getSaveImage() &&
                 saveImageParams.getSaveImage()) {
             AnkaMgmtCloud.markFuture(cloud, this);
         }

--- a/src/main/java/com/veertu/plugin/anka/AbstractAnkaSlave.java
+++ b/src/main/java/com/veertu/plugin/anka/AbstractAnkaSlave.java
@@ -114,11 +114,11 @@ public abstract class AbstractAnkaSlave extends Slave {
             Thread.sleep(3000); // Sleep for 3 seconds to avoid those spooky ChannelClosedException
             AnkaVmInstance vm = getAndLogInstance();
             if (vm != null) {
-                LOGGER.log(Level.INFO, "Node {0} Instance {1} is in state {2}", new Object[]{getNodeName(), instanceId, vm.getSessionState()});
+                LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1} is in state {2}"), new Object[]{getNodeName(), instanceId, vm.getSessionState()});
                 SaveImageParameters saveImageParams = template.getSaveImageParameters();
                 if (taskExecuted && saveImageParams != null && this.template.getSaveImageParameters().getSaveImage()
                         && saveImageParams.getSaveImage() && !hadProblemsInBuild && !hadUnknownBuildOutcome) {
-                    LOGGER.log(Level.INFO, "Node {0} Instance {1}, saving image", new Object[]{getNodeName(), instanceId});
+                    LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1}, saving image"), new Object[]{getNodeName(), instanceId});
 
                     synchronized (this) {
                         if (!this.saveImageSent) { // allow to send save image request only once
@@ -127,11 +127,11 @@ public abstract class AbstractAnkaSlave extends Slave {
                         }
                     }
                 } else {
-                    LOGGER.log(Level.INFO, "Node {0} Instance {1}, terminating", new Object[]{getNodeName(), instanceId});
+                    LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1}, terminating"), new Object[]{getNodeName(), instanceId});
                     cloud.terminateVMInstance(this.instanceId);
                 }
             } else {
-                LOGGER.log(Level.INFO, "Node {0} Instance {1} was not found, ensuring termination", new Object[]{getNodeName(), instanceId});
+                LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1} was not found, ensuring termination"), new Object[]{getNodeName(), instanceId});
             }
         } catch (AnkaMgmtException e) {
             throw new IOException(e);
@@ -145,9 +145,9 @@ public abstract class AbstractAnkaSlave extends Slave {
                     if (instance != null) {
                         state = instance.getSessionState();
                     }
-                    LOGGER.log(Level.INFO, "Node {0} Instance {1}, ensuring termination before node removal, state: {2}", new Object[]{getNodeName(), instanceId, state});
+                    LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1}, ensuring termination before node removal, state: {2}"), new Object[]{getNodeName(), instanceId, state});
                     if (instance == null || instance.isTerminatingOrTerminated()) {
-                        LOGGER.log(Level.INFO, "Node {0} Instance {1}, removing node since instance is terminated or not found", new Object[]{getNodeName(), instanceId});
+                        LOGGER.log(Level.INFO, AnkaLog.prefix("Node {0} Instance {1}, removing node since instance is terminated or not found"), new Object[]{getNodeName(), instanceId});
                         Jenkins.get().removeNode(this); // only agree to remove the node after the instance doesn't
                                                            // exist or is not started
                     }
@@ -245,12 +245,12 @@ public abstract class AbstractAnkaSlave extends Slave {
                 String vmId = vmInfo.getUuid();
                 String hostIp = vmInfo.getHostIp();
                 String vmStatus = vmInfo.getStatus();
-                LOGGER.log(Level.FINE, "Node {0} instance {1}. instance state: {2}, " +
-                                "template id: {3}, VM uuid: {4}, VM status: {5} host IP: {6}", new Object[]{ getNodeName(), instanceId, state,
+                LOGGER.log(Level.FINE, AnkaLog.prefix("Node {0} instance {1}. instance state: {2}, " +
+                                "template id: {3}, VM uuid: {4}, VM status: {5} host IP: {6}"), new Object[]{ getNodeName(), instanceId, state,
                         templateId, vmId, vmStatus, hostIp });
             } else {
-                LOGGER.log(Level.FINE, "Node {0} instance {1}. instance state: {2}, " +
-                                "template id: {3}",  new Object[]{ getNodeName(), instanceId, state,
+                LOGGER.log(Level.FINE, AnkaLog.prefix("Node {0} instance {1}. instance state: {2}, " +
+                                "template id: {3}"),  new Object[]{ getNodeName(), instanceId, state,
                         templateId});
             }
         } else {
@@ -265,7 +265,7 @@ public abstract class AbstractAnkaSlave extends Slave {
                 AnkaVmInstance instance = getAndLogInstance();
                 if (instance != null) {
                     String state = instance.getSessionState();
-                    LOGGER.log(Level.FINE, "Anka Node {0}, instance {1} is in state {2}",
+                    LOGGER.log(Level.FINE, AnkaLog.prefix("Anka Node {0}, instance {1} is in state {2}"),
                             new Object[]{name, instanceId, state});
                     if (instance.isStarted()) {
                         return true;

--- a/src/main/java/com/veertu/plugin/anka/AnkaCloudComputer.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaCloudComputer.java
@@ -7,17 +7,26 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 
 /**
  * Created by asafgur on 16/11/2016.
  */
 public class AnkaCloudComputer extends SlaveComputer {
+    private static final Logger LOGGER = Logger.getLogger(AnkaCloudComputer.class.getName());
+    enum BuildOutcome {
+        SUCCESS,
+        FAILURE,
+        UNKNOWN
+    }
 
     private final AbstractAnkaSlave slave;
     private final String cloudName;
     private AnkaCloudSlaveTemplate template;
     protected Run<?, ?> run;
+    private RunIdentity acceptedRunIdentity;
     private final String vmId;
     private boolean afterFirstConnection = false;
     private boolean launching;
@@ -106,20 +115,31 @@ public class AnkaCloudComputer extends SlaveComputer {
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
         super.taskAccepted(executor, task);
+        this.run = null;
+        this.acceptedRunIdentity = null;
+        this.slave.setHadUnknownBuildOutcome(false);
         if (task instanceof ExecutorStepExecution.PlaceholderTask) {
             this.run = ((ExecutorStepExecution.PlaceholderTask) task).run();
             if (this.run != null ){
                 this.slave.setDescription(this.run.getFullDisplayName());
                 this.slave.setJobNameAndNumber(this.run.getFullDisplayName());
+                this.acceptedRunIdentity = RunIdentity.fromRun(this.run);
             }
         } else {
+            String jobAndNumber;
             try {
-                String jobAndNumber = executor.getCurrentWorkUnit().getExecutable().toString();
+                jobAndNumber = executor.getCurrentWorkUnit().getExecutable().toString();
                 this.slave.setDescription(jobAndNumber);
                 this.slave.setJobNameAndNumber(jobAndNumber);
             } catch (NullPointerException e) {
-                this.slave.setDescription(executor.getDisplayName());
-                this.slave.setJobNameAndNumber(executor.getDisplayName());
+                jobAndNumber = executor.getDisplayName();
+                this.slave.setDescription(jobAndNumber);
+                this.slave.setJobNameAndNumber(jobAndNumber);
+            }
+            if (task instanceof Job) {
+                this.acceptedRunIdentity = parseRunIdentity((Job<?, ?>) task, jobAndNumber);
+            } else {
+                this.acceptedRunIdentity = parseRunIdentityFromDisplayName(jobAndNumber);
             }
         }
         this.slave.taskAccepted(executor, task);
@@ -129,8 +149,11 @@ public class AnkaCloudComputer extends SlaveComputer {
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
         this.slave.taskCompleted(executor, task, durationMS);
-        checkLatestJobAndChangeNodeBehaviour(task);
-        super.taskCompleted(executor, task, durationMS);
+        try {
+            safelyCheckLatestJobAndChangeNodeBehaviour(executor, task);
+        } finally {
+            super.taskCompleted(executor, task, durationMS);
+        }
 
     }
 
@@ -138,55 +161,217 @@ public class AnkaCloudComputer extends SlaveComputer {
     @Override
     public void taskCompletedWithProblems(Executor executor, Queue.Task task, long durationMS, Throwable problems) {
         this.slave.taskCompleted(executor, task, durationMS);
-        checkLatestJobAndChangeNodeBehaviour(task);
-        super.taskCompletedWithProblems(executor, task, durationMS, problems);
+        try {
+            safelyCheckLatestJobAndChangeNodeBehaviour(executor, task);
+        } finally {
+            super.taskCompletedWithProblems(executor, task, durationMS, problems);
+        }
     }
 
-    private void checkLatestJobAndChangeNodeBehaviour(Queue.Task task){
+    void safelyCheckLatestJobAndChangeNodeBehaviour(Executor executor, Queue.Task task) {
+        try {
+            checkLatestJobAndChangeNodeBehaviour(executor, task);
+        } catch (RuntimeException e) {
+            // Unknown/unstable metadata should never prevent run-once cleanup.
+            applyBuildOutcome(BuildOutcome.UNKNOWN);
+            LOGGER.log(Level.WARNING,
+                    String.format("Computer %s, instance %s failed to resolve build result for task %s",
+                            getName(), getVMId(), task),
+                    e);
+        }
+    }
+
+    private void checkLatestJobAndChangeNodeBehaviour(Executor executor, Queue.Task task){
 
         if (this.run != null) {
-            Result result = this.run.getResult();
-            if (result == null && this.template.getSaveImageParameters() != null && this.template.getSaveImageParameters().getSaveImage() && this.template.getSaveImageParameters().getWaitForBuildToFinish()) {
-                while (run.isBuilding()) {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                        break;
-                    }
-                }
-                result = this.run.getResult();
-            }
-            if (result == Result.FAILURE || result == Result.ABORTED || result == Result.UNSTABLE) {
-                this.slave.setHadErrorsOnBuild(true);
-            }
+            updateBuildOutcome(this.run, "pipeline run reference");
             return;
         }
 
-        // check the latest build and report back to slave object , in case keepAliveOnerror is set
-        if (!(task instanceof AbstractProject)) {
+        Run<?, ?> completedRun = getCompletedRun(executor, task);
+        if (completedRun == null) {
+            applyBuildOutcome(BuildOutcome.UNKNOWN);
+            AnkaMgmtCloud.Log("slave: %s, vm id: %s exited build with unknown outcome (no completed run found)",
+                    this.slave.getNodeName(), this.slave.getInstanceId());
             return;
         }
-        AbstractBuild b = ((AbstractProject)task).getLastBuild();
-        if (b == null) {
-            return;
+
+        updateBuildOutcome(completedRun, "completed run lookup");
+    }
+
+    private Run<?, ?> getCompletedRun(Executor executor, Queue.Task task) {
+        if (executor != null) {
+            Queue.Executable executable = executor.getCurrentExecutable();
+            if (executable instanceof Run) {
+                return (Run<?, ?>) executable;
+            }
         }
-        ResultTrend trend = ResultTrend.getResultTrend(b);
-        AnkaMgmtCloud.Log("slave: %s, vm id: %s exited build with trend: %s", this.slave.getNodeName(),
-                this.slave.getInstanceId(), trend.toString());
-        switch (trend){
-            case NOT_BUILT :
-            case FAILURE :
-            case STILL_FAILING :
-            case NOW_UNSTABLE:
-            case STILL_UNSTABLE :
-            case UNSTABLE :
-            case ABORTED :
-                this.slave.setHadErrorsOnBuild(true);
+
+        Run<?, ?> runFromAcceptedIdentity = getRunFromAcceptedIdentity(task);
+        if (runFromAcceptedIdentity != null) {
+            return runFromAcceptedIdentity;
+        }
+
+        if (this.acceptedRunIdentity != null) {
+            return null;
+        }
+
+        if (task instanceof Job) {
+            return ((Job<?, ?>) task).getLastCompletedBuild();
+        }
+
+        if (task instanceof AbstractProject) {
+            return ((AbstractProject<?, ?>) task).getLastCompletedBuild();
+        }
+
+        return null;
+    }
+
+    private Run<?, ?> getRunFromAcceptedIdentity(Queue.Task task) {
+        if (this.acceptedRunIdentity == null) {
+            return null;
+        }
+
+        Job<?, ?> job = resolveJobForIdentity(task, this.acceptedRunIdentity.getJobFullName());
+        if (job == null) {
+            return null;
+        }
+
+        return job.getBuildByNumber(this.acceptedRunIdentity.getBuildNumber());
+    }
+
+    private Job<?, ?> resolveJobForIdentity(Queue.Task task, String jobFullName) {
+        if (task instanceof Job) {
+            Job<?, ?> job = (Job<?, ?>) task;
+            if (job.getFullName().equals(jobFullName)) {
+                return job;
+            }
+        }
+
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return null;
+        }
+
+        return jenkins.getItemByFullName(jobFullName, Job.class);
+    }
+
+    private void updateBuildOutcome(Run<?, ?> completedRun, String source) {
+        Result result = resolveResult(completedRun);
+        BuildOutcome buildOutcome = resolveBuildOutcome(result);
+        applyBuildOutcome(buildOutcome);
+        switch (buildOutcome) {
+            case UNKNOWN:
+                AnkaMgmtCloud.Log("slave: %s, vm id: %s exited build with UNKNOWN outcome via %s",
+                        this.slave.getNodeName(), this.slave.getInstanceId(), source);
                 break;
-            case SUCCESS :
-            case FIXED :
-                this.slave.setHadErrorsOnBuild(false);
+            case SUCCESS:
+                AnkaMgmtCloud.Log("slave: %s, vm id: %s exited build with SUCCESS result via %s",
+                        this.slave.getNodeName(), this.slave.getInstanceId(), source);
+                break;
+            case FAILURE:
+                AnkaMgmtCloud.Log("slave: %s, vm id: %s exited build with FAILURE result %s via %s",
+                        this.slave.getNodeName(), this.slave.getInstanceId(), result, source);
+                break;
+        }
+    }
+
+    private Result resolveResult(Run<?, ?> completedRun) {
+        Result result = completedRun.getResult();
+        if (result != null) {
+            return result;
+        }
+
+        SaveImageParameters saveImageParameters = this.template.getSaveImageParameters();
+        if (saveImageParameters != null && saveImageParameters.getSaveImage() && saveImageParameters.getWaitForBuildToFinish()) {
+            while (completedRun.isBuilding()) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            return completedRun.getResult();
+        }
+
+        return null;
+    }
+
+    private void applyBuildOutcome(BuildOutcome buildOutcome) {
+        this.slave.setHadErrorsOnBuild(shouldMarkBuildAsErrorForKeepAlive(buildOutcome));
+        this.slave.setHadUnknownBuildOutcome(buildOutcome == BuildOutcome.UNKNOWN);
+    }
+
+    static BuildOutcome resolveBuildOutcome(Result result) {
+        if (result == null) {
+            return BuildOutcome.UNKNOWN;
+        }
+        if (result == Result.SUCCESS) {
+            return BuildOutcome.SUCCESS;
+        }
+        return BuildOutcome.FAILURE;
+    }
+
+    static boolean shouldMarkBuildAsErrorForKeepAlive(BuildOutcome buildOutcome) {
+        return buildOutcome == BuildOutcome.FAILURE;
+    }
+
+    static RunIdentity parseRunIdentityFromDisplayName(String jobDisplayName) {
+        if (jobDisplayName == null) {
+            return null;
+        }
+
+        int runSeparator = jobDisplayName.lastIndexOf(" #");
+        if (runSeparator <= 0 || runSeparator >= jobDisplayName.length() - 2) {
+            return null;
+        }
+
+        String jobName = jobDisplayName.substring(0, runSeparator).trim();
+        String buildNumberText = jobDisplayName.substring(runSeparator + 2).trim();
+        if (jobName.isEmpty()) {
+            return null;
+        }
+
+        try {
+            int buildNumber = Integer.parseInt(buildNumberText);
+            if (buildNumber <= 0) {
+                return null;
+            }
+            return new RunIdentity(jobName, buildNumber);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static RunIdentity parseRunIdentity(Job<?, ?> job, String jobDisplayName) {
+        RunIdentity runIdentityFromDisplayName = parseRunIdentityFromDisplayName(jobDisplayName);
+        if (runIdentityFromDisplayName == null) {
+            return null;
+        }
+
+        return new RunIdentity(job.getFullName(), runIdentityFromDisplayName.getBuildNumber());
+    }
+
+    static final class RunIdentity {
+        private final String jobFullName;
+        private final int buildNumber;
+
+        private RunIdentity(String jobFullName, int buildNumber) {
+            this.jobFullName = jobFullName;
+            this.buildNumber = buildNumber;
+        }
+
+        static RunIdentity fromRun(Run<?, ?> run) {
+            return new RunIdentity(run.getParent().getFullName(), run.getNumber());
+        }
+
+        String getJobFullName() {
+            return jobFullName;
+        }
+
+        int getBuildNumber() {
+            return buildNumber;
         }
     }
 

--- a/src/main/java/com/veertu/plugin/anka/AnkaCloudComputer.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaCloudComputer.java
@@ -117,7 +117,6 @@ public class AnkaCloudComputer extends SlaveComputer {
         super.taskAccepted(executor, task);
         this.run = null;
         this.acceptedRunIdentity = null;
-        this.slave.setHadUnknownBuildOutcome(false);
         if (task instanceof ExecutorStepExecution.PlaceholderTask) {
             this.run = ((ExecutorStepExecution.PlaceholderTask) task).run();
             if (this.run != null ){
@@ -301,7 +300,6 @@ public class AnkaCloudComputer extends SlaveComputer {
 
     private void applyBuildOutcome(BuildOutcome buildOutcome) {
         this.slave.setHadErrorsOnBuild(shouldMarkBuildAsErrorForKeepAlive(buildOutcome));
-        this.slave.setHadUnknownBuildOutcome(buildOutcome == BuildOutcome.UNKNOWN);
     }
 
     static BuildOutcome resolveBuildOutcome(Result result) {

--- a/src/main/java/com/veertu/plugin/anka/AnkaCloudComputer.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaCloudComputer.java
@@ -175,8 +175,9 @@ public class AnkaCloudComputer extends SlaveComputer {
             // Unknown/unstable metadata should never prevent run-once cleanup.
             applyBuildOutcome(BuildOutcome.UNKNOWN);
             LOGGER.log(Level.WARNING,
+                    AnkaLog.prefix(
                     String.format("Computer %s, instance %s failed to resolve build result for task %s",
-                            getName(), getVMId(), task),
+                            getName(), getVMId(), task)),
                     e);
         }
     }

--- a/src/main/java/com/veertu/plugin/anka/AnkaCloudComputerListener.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaCloudComputerListener.java
@@ -27,7 +27,7 @@ public class AnkaCloudComputerListener extends ComputerListener {
         if (c instanceof AnkaCloudComputer) {
             AnkaCloudComputer computer = (AnkaCloudComputer)c;
             if (c.isLaunchSupported()) {
-                LOGGER.log(Level.INFO, "Computer {0}, instance {1} failed to launch, terminating",
+                LOGGER.log(Level.INFO, AnkaLog.prefix("Computer {0}, instance {1} failed to launch, terminating"),
                         new Object[]{computer.getName(), computer.getVMId()});
                 computer.terminate();
             }

--- a/src/main/java/com/veertu/plugin/anka/AnkaLog.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaLog.java
@@ -1,0 +1,15 @@
+package com.veertu.plugin.anka;
+
+final class AnkaLog {
+    private static final String PREFIX = "[Anka] ";
+
+    private AnkaLog() {
+    }
+
+    static String prefix(String message) {
+        if (message == null || message.startsWith(PREFIX)) {
+            return message;
+        }
+        return PREFIX + message;
+    }
+}

--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -729,9 +729,7 @@ public class AnkaMgmtCloud extends Cloud {
             return;
         }
 
-        boolean terminationAccepted = ankaAPI.terminateInstance(id);
-
-        if (terminationAccepted) {
+        if (ankaAPI.terminateInstance(id)) {
             Log("Termination request for VM instance " + id + " accepted");
         } else {
             Log("Termination request for VM instance " + id + " was not accepted");

--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -729,30 +729,14 @@ public class AnkaMgmtCloud extends Cloud {
             return;
         }
 
-        ankaAPI.terminateInstance(id);
+        boolean terminationAccepted = ankaAPI.terminateInstance(id);
 
-        long startTime = System.currentTimeMillis();
-        long timeoutMs = 60_000;
-
-        while (System.currentTimeMillis() - startTime < timeoutMs) {
-            ankaVmInstance = ankaAPI.showInstance(id);
-
-            if (ankaVmInstance == null || ankaVmInstance.isTerminatingOrTerminated()) {
-                Log("VM instance " + id + " terminated successfully");
-                return;
-            }
-
-            try {
-                sleep(1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                Log("Thread was interrupted while waiting for instance termination");
-                throw new AnkaMgmtException("Thread was interrupted while waiting for instance termination");
-            }
+        if (terminationAccepted) {
+            Log("Termination request for VM instance " + id + " accepted");
+        } else {
+            Log("Termination request for VM instance " + id + " was not accepted");
+            throw new AnkaMgmtException("Failed to terminate VM instance " + id);
         }
-
-        Log("Failed to terminate VM instance " + id + " within timeout period");
-        throw new AnkaMgmtException("Failed to terminate VM instance " + id + " within timeout period");
     }
 
     public AnkaVmInstance showInstance(String id) throws AnkaMgmtException {

--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -660,7 +660,6 @@ public class AnkaMgmtCloud extends Cloud {
         Label label = state.getLabel();
         AnkaCloudSlaveTemplate template = getTemplate(label);
         if (template == null) {
-            Log("Cannot provision label '%s': no matching Anka template found in cloud '%s'", label, getCloudName());
             return false;
         }
         int cloudCapacity = getCloudCapacity();

--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -86,6 +86,7 @@ public class AnkaMgmtCloud extends Cloud {
         if (slave != null) s = String.format("[%s] ", slave.getNodeName());
         if (slaveComputer != null) s = String.format("[%s] ", slaveComputer.getName());
         s = s + String.format(format, args);
+        s = AnkaLog.prefix(s);
         s = s + "\n";
         if (listener != null) listener.getLogger().print(s);
         MgmtLogger.log(Level.INFO, s);
@@ -510,6 +511,8 @@ public class AnkaMgmtCloud extends Cloud {
                     if (cloudCapacity > 0) {
                         int allowedCloudCapacity = cloudCapacity - nodeCount.numNodes;
                         if (allowedCloudCapacity <= 0) {
+                            Log("Skipping provisioning for label '%s': cloud capacity reached (%d/%d active nodes)",
+                                    label, nodeCount.numNodes, cloudCapacity);
                             return plannedNodes;
                         }
                         if (number > allowedCloudCapacity) {
@@ -519,6 +522,8 @@ public class AnkaMgmtCloud extends Cloud {
                     if (t.getInstanceCapacity() > 0) {
                         int allowedTemplateCapacity = t.getInstanceCapacity() - nodeCount.numNodesPerLabel;
                         if (allowedTemplateCapacity <= 0) {
+                            Log("Skipping provisioning for label '%s': template capacity reached (%d/%d active nodes for template '%s')",
+                                    label, nodeCount.numNodesPerLabel, t.getInstanceCapacity(), t.getDisplayName());
                             return plannedNodes;
                         }
                         if (number > allowedTemplateCapacity) {
@@ -655,12 +660,19 @@ public class AnkaMgmtCloud extends Cloud {
         Label label = state.getLabel();
         AnkaCloudSlaveTemplate template = getTemplate(label);
         if (template == null) {
+            Log("Cannot provision label '%s': no matching Anka template found in cloud '%s'", label, getCloudName());
             return false;
         }
         int cloudCapacity = getCloudCapacity();
         if (template.getInstanceCapacity() > 0 || cloudCapacity >= 0) {
             NodeCountResponse countResponse = getNumOfRunningNodesPerLabel(label);
-            if ((cloudCapacity >= 0 && countResponse.numNodes >= cloudCapacity) || (template.getInstanceCapacity() > 0 && countResponse.numNodesPerLabel >= template.getInstanceCapacity())) {
+            if (cloudCapacity >= 0 && countResponse.numNodes >= cloudCapacity) {
+                Log("Cannot provision label '%s': cloud capacity reached (%d/%d active nodes)", label, countResponse.numNodes, cloudCapacity);
+                return false;
+            }
+            if (template.getInstanceCapacity() > 0 && countResponse.numNodesPerLabel >= template.getInstanceCapacity()) {
+                Log("Cannot provision label '%s': template capacity reached (%d/%d active nodes for template '%s')",
+                        label, countResponse.numNodesPerLabel, template.getInstanceCapacity(), template.getDisplayName());
                 return false;
             }
         }

--- a/src/main/java/com/veertu/plugin/anka/AnkaPlannedNodeCreator.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaPlannedNodeCreator.java
@@ -7,7 +7,6 @@ import hudson.model.Computer;
 import hudson.model.Node;
 import hudson.slaves.NodeProvisioner;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -24,14 +23,28 @@ public class AnkaPlannedNodeCreator {
 
     public static NodeProvisioner.PlannedNode createPlannedNode(final AnkaMgmtCloud cloud, final AnkaCloudSlaveTemplate template, final AbstractAnkaSlave slave) {
         return new NodeProvisioner.PlannedNode(template.getDisplayName(),
-                Computer.threadPoolForRemoting.submit(new Callable<Node>() {
-
-
-                    public Node call() throws Exception {
+                Computer.threadPoolForRemoting.submit(() -> {
+                    try {
                         return waitAndConnect(cloud, template, slave);
+                    } catch (InterruptedException interruptedException) {
+                        terminateProvisioningInstance(cloud, slave, interruptedException);
+                        Thread.currentThread().interrupt();
+                        return null;
                     }
                 })
                 , template.getNumberOfExecutors());
+    }
+
+    private static void terminateProvisioningInstance(AnkaMgmtCloud cloud, AbstractAnkaSlave slave, InterruptedException interruptedException) {
+        String instanceId = slave.getInstanceId();
+        LOGGER.log(Level.WARNING, AnkaLog.prefix("Provisioning interrupted for instance {0}, sending termination"), instanceId);
+        try {
+            cloud.terminateVMInstance(instanceId, slave);
+        } catch (AnkaMgmtException terminateError) {
+            LOGGER.log(Level.WARNING, AnkaLog.prefix("Failed to terminate interrupted instance " + instanceId), terminateError);
+        } finally {
+            LOGGER.log(Level.FINE, AnkaLog.prefix("Provisioning interruption stacktrace for instance " + instanceId), interruptedException);
+        }
     }
 
     public static Node waitAndConnect(final AnkaMgmtCloud cloud, final AnkaCloudSlaveTemplate template, final AbstractAnkaSlave slave) throws AnkaMgmtException, InterruptedException {
@@ -41,7 +54,7 @@ public class AnkaPlannedNodeCreator {
             int vmCheckTime = cloud.getVmPollTime();
             AnkaVmInstance instance = cloud.showInstance(instanceId);
             if (instance == null) {
-                LOGGER.log(Level.WARNING, "instance `{0}` not found in cloud {1}. Terminate provisioning ",
+                LOGGER.log(Level.WARNING, AnkaLog.prefix("instance `{0}` not found in cloud {1}. Terminate provisioning "),
                         new Object[]{instanceId, cloud.getCloudName()});
                 return null;
             }
@@ -83,10 +96,10 @@ public class AnkaPlannedNodeCreator {
                 final long sinceStarted = System.currentTimeMillis() - timeStarted;
                 int schedulingTimeout = template.getSchedulingTimeout();
                 long schedulingTimeoutMillis = TimeUnit.SECONDS.toMillis(schedulingTimeout);
-                LOGGER.log(Level.FINE,"Instance {0} is scheduling for {1} seconds",
+                LOGGER.log(Level.FINE, AnkaLog.prefix("Instance {0} is scheduling for {1} seconds"),
                             new Object[]{instanceId, sinceStarted / 1000});
                 if (sinceStarted > schedulingTimeoutMillis) {
-                    LOGGER.log(Level.WARNING,"Instance {0} reached it's scheduling timeout of {1} seconds, terminating provisioning",
+                    LOGGER.log(Level.WARNING, AnkaLog.prefix("Instance {0} reached it's scheduling timeout of {1} seconds, terminating provisioning"),
                             new Object[]{instanceId, schedulingTimeout});
                     cloud.terminateVMInstance(instanceId);
                     return null;
@@ -96,7 +109,7 @@ public class AnkaPlannedNodeCreator {
             }
 
             if (instance.isTerminatingOrTerminated() || instance.isInError()) {
-                LOGGER.log(Level.WARNING,"Instance {0} is in unexpected state {1}",
+                LOGGER.log(Level.WARNING, AnkaLog.prefix("Instance {0} is in unexpected state {1}"),
                         new Object[]{instanceId, instance.getSessionState()});
                 cloud.terminateVMInstance(instanceId);
                 return null;

--- a/src/main/java/com/veertu/plugin/anka/AnkaProvisioningStrategy.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaProvisioningStrategy.java
@@ -58,6 +58,7 @@ public class AnkaProvisioningStrategy extends NodeProvisioner.Strategy {
             if (currentDemand > availableCapacity) {
                 Jenkins jenkinsInstance = Jenkins.get();
                 Cloud.CloudState cloudState = new Cloud.CloudState(label, strategyState.getAdditionalPlannedCapacity());
+                boolean cloudProvisioningTriggered = false;
                 for (Cloud cloud : jenkinsInstance.clouds) {
                     if (cloud instanceof AnkaMgmtCloud && cloud.canProvision(cloudState)) {
                         Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(cloudState, currentDemand - availableCapacity);
@@ -65,9 +66,14 @@ public class AnkaProvisioningStrategy extends NodeProvisioner.Strategy {
                         strategyState.recordPendingLaunches(plannedNodes);
                         availableCapacity += plannedNodes.size();
                         AnkaMgmtCloud.Log("After provisioning, available capacity=%d, currentDemand=%d", availableCapacity, currentDemand);
+                        cloudProvisioningTriggered = true;
                         break;
                     }
 
+                }
+                if (!cloudProvisioningTriggered) {
+                    AnkaMgmtCloud.Log("No eligible Anka cloud could provision label '%s' (available=%d, demand=%d)",
+                            label, availableCapacity, currentDemand);
                 }
             }
         }

--- a/src/main/java/com/veertu/plugin/anka/AnkaSlaveMonitor.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaSlaveMonitor.java
@@ -69,7 +69,7 @@ public class AnkaSlaveMonitor extends AsyncPeriodicWork {
     }
 
     private void cleanDynamicTemplates() {
-        LOGGER.log(Level.INFO, "AnkaSlaveMonitor cleaning dynamic templates...");
+        LOGGER.log(Level.INFO, AnkaLog.prefix("AnkaSlaveMonitor cleaning dynamic templates..."));
         List<AnkaMgmtCloud> clouds = getAnkaClouds();
         for (AnkaMgmtCloud cloud : clouds) {
 
@@ -77,7 +77,7 @@ public class AnkaSlaveMonitor extends AsyncPeriodicWork {
 
                 String jobId = template.getBuildId();
                 if (jobId.equals("")) {
-                    LOGGER.log(Level.WARNING, "dynamic template with label {0} has no build id assigned",
+                    LOGGER.log(Level.WARNING, AnkaLog.prefix("dynamic template with label {0} has no build id assigned"),
                             new Object[]{template.getLabel()});
                     continue;
                 }
@@ -86,7 +86,7 @@ public class AnkaSlaveMonitor extends AsyncPeriodicWork {
                 try {
                     run = fromExternalizableId(jobId);
                 } catch (IllegalArgumentException e) {
-                    LOGGER.log(Level.WARNING, "invalid job id {0} stored in dynamic template (label {1})",
+                    LOGGER.log(Level.WARNING, AnkaLog.prefix("invalid job id {0} stored in dynamic template (label {1})"),
                             new Object[]{jobId, template.getLabel()});
                 } finally {
                     if (run == null || !run.isBuilding()) {
@@ -98,9 +98,9 @@ public class AnkaSlaveMonitor extends AsyncPeriodicWork {
     }
 
     private void removeDeadNodes() {
-        LOGGER.log(Level.INFO, "AnkaSlaveMonitor checking nodes...");
+        LOGGER.log(Level.INFO, AnkaLog.prefix("AnkaSlaveMonitor checking nodes..."));
         for (AbstractAnkaSlave ankaNode : NodeIterator.nodes(AbstractAnkaSlave.class)) {
-            LOGGER.log(Level.FINE, "Checking Anka Node {0}, instance {1}",
+            LOGGER.log(Level.FINE, AnkaLog.prefix("Checking Anka Node {0}, instance {1}"),
                     new Object[]{ankaNode.getNodeName(), ankaNode.getInstanceId()});
             AnkaCloudComputer computer = (AnkaCloudComputer) ankaNode.getComputer();
             if (computer != null && computer.isConnecting()) {
@@ -108,12 +108,12 @@ public class AnkaSlaveMonitor extends AsyncPeriodicWork {
             }
             try {
                 if (!ankaNode.isAlive()) {
-                    LOGGER.log(Level.WARNING, "Anka Node {0}, instance {1}: instance is not alive - terminating",
+                    LOGGER.log(Level.WARNING, AnkaLog.prefix("Anka Node {0}, instance {1}: instance is not alive - terminating"),
                             new Object[]{ankaNode.getNodeName(), ankaNode.getInstanceId()});
                     ankaNode.terminate();
                 }
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING,"Anka VM failed to terminate: " + ankaNode.getInstanceId());
+                LOGGER.log(Level.WARNING, AnkaLog.prefix("Anka VM failed to terminate: " + ankaNode.getInstanceId()));
                 e.printStackTrace();
             }
         }

--- a/src/main/java/com/veertu/plugin/anka/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/com/veertu/plugin/anka/RunOnceCloudRetentionStrategy.java
@@ -21,9 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-/**
- * Created by avia on 12/07/2016.
- */
 public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudComputer> implements ExecutorListener, Cloneable {
     private static final transient Logger LOGGER = Logger.getLogger(RunOnceCloudRetentionStrategy.class.getName());
 
@@ -44,9 +41,9 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
     @Override
     public long check(final AnkaCloudComputer computer) {
         try {
-            LOGGER.log(Level.INFO, "Checking computer {0}", computer.getName());
+            LOGGER.log(Level.INFO, AnkaLog.prefix("Checking computer {0}"), computer.getName());
             if (computer.countBusy() > 1) {
-                LOGGER.log(Level.FINE, "Computer {0} has {1} busy executors", new Object[]{computer.getName(), computer.countBusy()});
+                LOGGER.log(Level.FINE, AnkaLog.prefix("Computer {0} has {1} busy executors"), new Object[]{computer.getName(), computer.countBusy()});
                 return idleMinutes;
             }
 
@@ -64,14 +61,14 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
 
 
             if (reconnectionRetries >= MAX_RECONNECTION_RETRIES) { // we tried to reconnect - but it's enough now
-                LOGGER.log(Level.WARNING, "Computer {0}, instance {1} is terminating because it has reached it's max reconnection retries",
+                LOGGER.log(Level.WARNING, AnkaLog.prefix("Computer {0}, instance {1} is terminating because it has reached it's max reconnection retries"),
                         new Object[]{computer.getName(), computer.getVMId()});
                 done(computer);
                 return idleMinutes;
             }
 
             if (!computer.isOnline()) {
-                LOGGER.log(Level.WARNING, "Computer {0}, instance {1} is offline, trying to reconnect",
+                LOGGER.log(Level.WARNING, AnkaLog.prefix("Computer {0}, instance {1} is offline, trying to reconnect"),
                         new Object[]{computer.getName(), computer.getVMId()});
                 boolean forceReconnect = false;
                 if (reconnectionRetries > 4) {
@@ -86,7 +83,7 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
             if(computer.isIdle()) {
                 final long idleMilliseconds = System.currentTimeMillis() - computer.getIdleStartMilliseconds();
                 if(idleMilliseconds > TimeUnit.MINUTES.toMillis(idleMinutes)) {
-                    LOGGER.log(Level.WARNING, "Computer {0}, instance {1} is terminating due to idle timeout",
+                    LOGGER.log(Level.WARNING, AnkaLog.prefix("Computer {0}, instance {1} is terminating due to idle timeout"),
                             new Object[]{computer.getName(), computer.getVMId()});
                     done(computer);
                 }
@@ -101,14 +98,14 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
     @Override
     public void taskAccepted(Executor executor, Queue.Task task) {
         AnkaCloudComputer computer = (AnkaCloudComputer) executor.getOwner();
-        LOGGER.log(Level.INFO, "Computer {0}, instance {2} accepted task {1}",
+        LOGGER.log(Level.INFO, AnkaLog.prefix("Computer {0}, instance {2} accepted task {1}"),
                 new Object[]{computer.getName(), task.toString(), computer.getVMId()});
     }
 
     @Override
     public void taskCompleted(final Executor executor, final Queue.Task task, final long durationMS) {
         AnkaCloudComputer computer = (AnkaCloudComputer) executor.getOwner();
-        LOGGER.log(Level.INFO, "Computer {0}, instance {2} completed task {1}",
+        LOGGER.log(Level.INFO, AnkaLog.prefix("Computer {0}, instance {2} completed task {1}"),
                 new Object[]{computer.getName(), task.toString(), computer.getVMId()});
         computer.setAcceptingTasks(false);
         done(computer);
@@ -117,7 +114,7 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
     @Override
     public void taskCompletedWithProblems(final Executor executor, final Queue.Task task, final long durationMS, final Throwable problems) {
         AnkaCloudComputer computer = (AnkaCloudComputer) executor.getOwner();
-        LOGGER.log(Level.INFO, "Computer {0}, instance {2} accepted task {1} with problems",
+        LOGGER.log(Level.INFO, AnkaLog.prefix("Computer {0}, instance {2} accepted task {1} with problems"),
                 new Object[]{computer.getName(), task.toString(), computer.getVMId()});
         computer.setAcceptingTasks(false);
         done(computer);
@@ -171,7 +168,7 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
                     computer.firstConnectionAttempted(); // in case jenkins restarted before we could set this property
                     return;
                 } catch (AnkaMgmtException | IOException e) {
-                    LOGGER.info("Got exception while handling node in jenkins startup");
+                    LOGGER.info(AnkaLog.prefix("Got exception while handling node in jenkins startup"));
                     e.printStackTrace();
                     return;
                 }
@@ -179,7 +176,7 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
         }
 
 
-        LOGGER.info("Start requested for " + computer.getName());
+        LOGGER.info(AnkaLog.prefix("Start requested for " + computer.getName()));
         computer.connect(false);
     }
 

--- a/src/main/java/com/veertu/plugin/anka/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/com/veertu/plugin/anka/RunOnceCloudRetentionStrategy.java
@@ -123,13 +123,15 @@ public class RunOnceCloudRetentionStrategy extends RetentionStrategy<AnkaCloudCo
     private void done(final AnkaCloudComputer computer) {
         AnkaMgmtCloud.Log("Computer %s is done, terminating", computer.getName());
         AbstractAnkaSlave node = computer.getNode();
+        int busyExecutors = computer.countBusy();
+        boolean canTerminate = node != null && node.canTerminate();
         if (node != null) {
             AnkaMgmtCloud.Log("computer %s node %s found", computer.getName(), node.getNodeName());
-            if (computer.countBusy() > 1) {
+            if (busyExecutors > 1) {
                 AnkaMgmtCloud.Log("computer %s is busy, not terminating", computer.getName());
                 return;
             }
-            if ( node.canTerminate()) {
+            if (canTerminate) {
                 AnkaMgmtCloud.Log("terminating computer %s node %s", computer.getName(), node.getNodeName());
                 try {
                     node.terminate();

--- a/src/main/resources/com/veertu/plugin/anka/AnkaMgmtCloud/config.jelly
+++ b/src/main/resources/com/veertu/plugin/anka/AnkaMgmtCloud/config.jelly
@@ -148,7 +148,8 @@
     }
 
     .anka-build-plugin-head-advanced .dropdownList-container div.jenkins-form-item {
-      width: 220px;
+      width: 100% !important;
+      max-width: 100% !important;
       margin: 5px;
       padding: 10px 17px 17px 17px;
       color: #5e2e9b;
@@ -228,11 +229,7 @@
         color: #5e2e9b !important;
     }
 
-    .anka-build-plugin-head-advanced .tbody {
-      display: flex !important;
-      flex-wrap: wrap;
-    }
-    .anka-build-plugin-head-advanced .tbody .form-group {
+    .anka-build-plugin-head-advanced .advancedBody .form-group {
       max-width: 300px;
     }
     .anka-build-plugin-head-advanced .advancedLink {
@@ -313,6 +310,10 @@
       margin: 10px 0px 0px 0px;
     }
 
+    .repeated-chunk__header {
+      display: none !important;
+    }
+
   </style>
   <div class="anka-build-plugin-group">
     <div class="anka-build-plugin-head-group">
@@ -338,40 +339,38 @@
       </div>
       <div class="anka-build-plugin-head-advanced">
         <f:block>
-          <table>
-            <f:optionalBlock name="dynamic" title="Advanced">
-              <f:entry title="${%Launch Timeout}" field="launchTimeout" description="Launch timeout in seconds">
-                <f:textbox clazz="number" default="2000"/>
-              </f:entry>
-              <f:entry title="${%Launch Retries}" field="maxLaunchRetries" description="Launch retries">
-                <f:textbox clazz="number" default="5"/>
-              </f:entry>
-              <f:entry title="${%Launch Retry Wait Time (seconds)}" field="launchRetryWaitTime" description="The number of seconds to wait between retries">
-                <f:textbox clazz="number" default="5"/>
-              </f:entry>
-              <f:entry title="${%Launch Delay (seconds)}" field="sshLaunchDelaySeconds" description="The number of seconds to wait before starting the launch process">
-                <f:textbox clazz="number" default="15"/>
-              </f:entry>
-              <f:entry title="${%VM IP Assign Wait Time (seconds)}" field="vmIPAssignWaitSeconds" description="Number of seconds to wait for the VM IP to be assigned (works only for VMs with bridged network adapter)">
-                <f:textbox clazz="number" default="10"/>
-              </f:entry>
-              <f:entry title="${%VM IP Assign Retries}" field="vmIPAssignRetries" description="Number of retries to read the assigned VM IP (works only for VMs with bridged network adapter)">
-                <f:textbox clazz="number" default="6"/>
-              </f:entry>
-              <f:entry title="${%Monitor Recurrence (minute)}" field="monitorRecurrenceMinutes" description="Number of minutes to check for dead instances (global). min 1 minute">
-                <f:textbox clazz="number" default="10"/>
-              </f:entry>
-              <f:entry title="${%Connection Keep Alive (seconds)}" field="connectionKeepAliveSeconds" description="Number of seconds to keep tcp connection alive">
-                <f:textbox clazz="number" default="120"/>
-              </f:entry>
-              <f:entry title="${%Maximum HTTP Connections}" field="maxConnections" description="Limit for http connection (for the controller)">
-                <f:textbox clazz="number" default="50"/>
-              </f:entry>
-              <f:entry title="${%VM Poll Time (milliseconds)}" field="vmPollTime" description="Time in milliseconds to poll during VM creation">
-                <f:textbox clazz="number" default="5000"/>
-              </f:entry>
-            </f:optionalBlock>
-          </table>
+          <f:advanced>
+            <f:entry title="${%Launch Timeout}" field="launchTimeout" description="Launch timeout in seconds">
+              <f:textbox clazz="number" default="2000"/>
+            </f:entry>
+            <f:entry title="${%Launch Retries}" field="maxLaunchRetries" description="Launch retries">
+              <f:textbox clazz="number" default="5"/>
+            </f:entry>
+            <f:entry title="${%Launch Retry Wait Time (seconds)}" field="launchRetryWaitTime" description="The number of seconds to wait between retries">
+              <f:textbox clazz="number" default="5"/>
+            </f:entry>
+            <f:entry title="${%Launch Delay (seconds)}" field="sshLaunchDelaySeconds" description="The number of seconds to wait before starting the launch process">
+              <f:textbox clazz="number" default="15"/>
+            </f:entry>
+            <f:entry title="${%VM IP Assign Wait Time (seconds)}" field="vmIPAssignWaitSeconds" description="Number of seconds to wait for the VM IP to be assigned (works only for VMs with bridged network adapter)">
+              <f:textbox clazz="number" default="10"/>
+            </f:entry>
+            <f:entry title="${%VM IP Assign Retries}" field="vmIPAssignRetries" description="Number of retries to read the assigned VM IP (works only for VMs with bridged network adapter)">
+              <f:textbox clazz="number" default="6"/>
+            </f:entry>
+            <f:entry title="${%Monitor Recurrence (minute)}" field="monitorRecurrenceMinutes" description="Number of minutes to check for dead instances (global). min 1 minute">
+              <f:textbox clazz="number" default="10"/>
+            </f:entry>
+            <f:entry title="${%Connection Keep Alive (seconds)}" field="connectionKeepAliveSeconds" description="Number of seconds to keep tcp connection alive">
+              <f:textbox clazz="number" default="120"/>
+            </f:entry>
+            <f:entry title="${%Maximum HTTP Connections}" field="maxConnections" description="Limit for http connection (for the controller)">
+              <f:textbox clazz="number" default="50"/>
+            </f:entry>
+            <f:entry title="${%VM Poll Time (milliseconds)}" field="vmPollTime" description="Time in milliseconds to poll during VM creation">
+              <f:textbox clazz="number" default="5000"/>
+            </f:entry>
+          </f:advanced>
         </f:block>
       </div>
       <h2>Security</h2>

--- a/src/test/java/com/veertu/plugin/anka/AnkaCloudComputerTest.java
+++ b/src/test/java/com/veertu/plugin/anka/AnkaCloudComputerTest.java
@@ -1,0 +1,54 @@
+package com.veertu.plugin.anka;
+
+import hudson.model.Result;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class AnkaCloudComputerTest {
+
+    @Test
+    public void shouldResolveNullResultToUnknownOutcome() {
+        assertThat(AnkaCloudComputer.resolveBuildOutcome(null), is(AnkaCloudComputer.BuildOutcome.UNKNOWN));
+    }
+
+    @Test
+    public void shouldResolveSuccessResultToSuccessOutcome() {
+        assertThat(AnkaCloudComputer.resolveBuildOutcome(Result.SUCCESS), is(AnkaCloudComputer.BuildOutcome.SUCCESS));
+    }
+
+    @Test
+    public void shouldResolveFailureResultToFailureOutcome() {
+        assertThat(AnkaCloudComputer.resolveBuildOutcome(Result.FAILURE), is(AnkaCloudComputer.BuildOutcome.FAILURE));
+    }
+
+    @Test
+    public void shouldResolveUnstableResultToFailureOutcome() {
+        assertThat(AnkaCloudComputer.resolveBuildOutcome(Result.UNSTABLE), is(AnkaCloudComputer.BuildOutcome.FAILURE));
+    }
+
+    @Test
+    public void shouldMarkOnlyFailureOutcomeAsKeepAliveError() {
+        assertThat(AnkaCloudComputer.shouldMarkBuildAsErrorForKeepAlive(AnkaCloudComputer.BuildOutcome.FAILURE), is(true));
+        assertThat(AnkaCloudComputer.shouldMarkBuildAsErrorForKeepAlive(AnkaCloudComputer.BuildOutcome.UNKNOWN), is(false));
+        assertThat(AnkaCloudComputer.shouldMarkBuildAsErrorForKeepAlive(AnkaCloudComputer.BuildOutcome.SUCCESS), is(false));
+    }
+
+    @Test
+    public void shouldParseRunIdentityFromFullDisplayName() {
+        AnkaCloudComputer.RunIdentity runIdentity =
+                AnkaCloudComputer.parseRunIdentityFromDisplayName("folder/job-name #123");
+
+        assertThat(runIdentity.getJobFullName(), is("folder/job-name"));
+        assertThat(runIdentity.getBuildNumber(), is(123));
+    }
+
+    @Test
+    public void shouldReturnNullWhenDisplayNameHasNoBuildNumber() {
+        AnkaCloudComputer.RunIdentity runIdentity =
+                AnkaCloudComputer.parseRunIdentityFromDisplayName("folder/job-name");
+
+        assertThat(runIdentity == null, is(true));
+    }
+}

--- a/src/test/java/com/veertu/plugin/anka/AnkaCloudComputerTest.java
+++ b/src/test/java/com/veertu/plugin/anka/AnkaCloudComputerTest.java
@@ -51,4 +51,88 @@ public class AnkaCloudComputerTest {
 
         assertThat(runIdentity == null, is(true));
     }
+
+    @Test
+    public void shouldReturnNullWhenDisplayNameIsNull() {
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName(null) == null, is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenDisplayNameIsEmpty() {
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName("") == null, is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenBuildNumberIsNotNumeric() {
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName("folder/job-name #abc") == null, is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenBuildNumberIsZero() {
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName("folder/job-name #0") == null, is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenBuildNumberIsNegative() {
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName("folder/job-name #-1") == null, is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenNoSpaceBeforeHash() {
+        // "name#42" lacks the Jenkins-standard " #" separator and must be rejected so
+        // we do not misattribute outcomes to a spurious job name. This directly protects
+        // the run-once cleanup from picking the wrong build.
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName("name#42") == null, is(true));
+    }
+
+    @Test
+    public void shouldReturnNullWhenJobNameIsBlank() {
+        assertThat(AnkaCloudComputer.parseRunIdentityFromDisplayName(" #42") == null, is(true));
+    }
+
+    @Test
+    public void shouldParseIdentityWhenJobNameContainsNestedFolders() {
+        AnkaCloudComputer.RunIdentity runIdentity =
+                AnkaCloudComputer.parseRunIdentityFromDisplayName("top-folder/mid-folder/leaf-job #7");
+
+        assertThat(runIdentity.getJobFullName(), is("top-folder/mid-folder/leaf-job"));
+        assertThat(runIdentity.getBuildNumber(), is(7));
+    }
+
+    @Test
+    public void shouldParseIdentityAndTrimTrailingWhitespace() {
+        AnkaCloudComputer.RunIdentity runIdentity =
+                AnkaCloudComputer.parseRunIdentityFromDisplayName("job-name #42   ");
+
+        assertThat(runIdentity.getJobFullName(), is("job-name"));
+        assertThat(runIdentity.getBuildNumber(), is(42));
+    }
+
+    @Test
+    public void shouldParseIdentityUsingLastHashSeparator() {
+        // Job names can legally contain '#', so we anchor on the last " #" to locate
+        // the build number segment.
+        AnkaCloudComputer.RunIdentity runIdentity =
+                AnkaCloudComputer.parseRunIdentityFromDisplayName("weird #name #99");
+
+        assertThat(runIdentity.getJobFullName(), is("weird #name"));
+        assertThat(runIdentity.getBuildNumber(), is(99));
+    }
+
+    @Test
+    public void shouldResolveAbortedResultToFailureOutcome() {
+        assertThat(AnkaCloudComputer.resolveBuildOutcome(Result.ABORTED), is(AnkaCloudComputer.BuildOutcome.FAILURE));
+    }
+
+    @Test
+    public void shouldResolveNotBuiltResultToFailureOutcome() {
+        assertThat(AnkaCloudComputer.resolveBuildOutcome(Result.NOT_BUILT), is(AnkaCloudComputer.BuildOutcome.FAILURE));
+    }
+
+    @Test
+    public void shouldNotMarkUnknownOutcomeAsKeepAliveError() {
+        // UNKNOWN outcomes must not flip hadErrorsOnBuild, otherwise keepAliveOnError
+        // could hold a run-once agent alive and let a pending task pick it up.
+        assertThat(AnkaCloudComputer.shouldMarkBuildAsErrorForKeepAlive(AnkaCloudComputer.BuildOutcome.UNKNOWN), is(false));
+    }
 }


### PR DESCRIPTION
1. https://github.com/jenkinsci/anka-build-plugin/pull/48: Plugin sends 2 consecutive/duplicate termination requests
2. Ephemeral/run-once VMs were sometimes getting reused after a job finished
3. New logs to help know when capacity is being reached: `INFO: Cannot provision label 'local-anka-cloud-label-ssh': cloud capacity reached (2/2 active nodes)`
4. Logging now prefixed with [Anka]
6. Improved "Advanced" settings rendering/behavior in Jenkins config UI. It wasn't allowing us to close after opening and also showed as a checkbox. Also, hiding `repeated-chunk__header` in UI to remove empty padding in elements.