### PR TITLE
v2.16.1

### DIFF
--- a/src/main/java/com/veertu/RoundRobin.java
+++ b/src/main/java/com/veertu/RoundRobin.java
@@ -140,4 +140,16 @@ public class RoundRobin {
             }
         }
     }
+
+    public boolean anyEndpointUsesHttps() {
+        synchronized (valuesLock) {
+            for (WeighedURL endpoint : values) {
+                String url = endpoint.getUrl();
+                if (url != null && url.regionMatches(true, 0, "https://", 0, 8)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaAPI.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaAPI.java
@@ -52,6 +52,10 @@ public class AnkaAPI {
         this.communicator.setApiAuthLogContext(apiAuthLogContext);
     }
 
+    public void setCloudName(String cloudName) {
+        this.communicator.setCloudName(cloudName);
+    }
+
     public List<AnkaVmTemplate> listTemplates() throws AnkaMgmtException {
         return communicator.listTemplates();
     }

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaMgmtCommunicator.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaMgmtCommunicator.java
@@ -25,7 +25,6 @@ import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -68,6 +67,8 @@ public class AnkaMgmtCommunicator {
     protected transient CloseableHttpClient httpClient;
     /** Runtime-only label for error logs; not a secret and not persisted. */
     protected transient String apiAuthLogContext;
+    /** Runtime-only name of the Anka cloud this communicator serves; used to attribute logs. */
+    protected transient String cloudName;
 
     public AnkaMgmtCommunicator(String url) {
         try {
@@ -129,16 +130,24 @@ public class AnkaMgmtCommunicator {
         this.apiAuthLogContext = apiAuthLogContext;
     }
 
+    public void setCloudName(String cloudName) {
+        this.cloudName = cloudName;
+    }
+
     protected void logException(Throwable exception) {
         if (apiAuthLogContext != null && !apiAuthLogContext.isEmpty()) {
             AnkaMgmtCloud.Log(
-                    "Got exception using credential: %s: %s %s",
+                    "%s: Got exception using credential: %s: %s %s",
+                    AnkaSdkLog.cloudLabel(cloudName),
                     apiAuthLogContext,
                     exception.getClass().getName(),
                     exception.getMessage());
             return;
         }
-        AnkaMgmtCloud.Log("Got exception: %s %s", exception.getClass().getName(), exception.getMessage());
+        AnkaMgmtCloud.Log("%s: Got exception: %s %s",
+                AnkaSdkLog.cloudLabel(cloudName),
+                exception.getClass().getName(),
+                exception.getMessage());
     }
 
     public List<AnkaVmTemplate> listTemplates() throws AnkaMgmtException {
@@ -726,6 +735,7 @@ public class AnkaMgmtCommunicator {
             Certificate certificate = RootCaCertificateParser.parsePemToCertificate(rootCA);
             keystore.setCertificateEntry("rootCA", certificate);
         }
+        logTlsTrustPosture();
 
         SSLContext sslContext = this.getSSLContext(keystore);
         PoolingHttpClientConnectionManager cm = getConnectionManager(sslContext);
@@ -772,11 +782,28 @@ public class AnkaMgmtCommunicator {
             return TrustAllStrategy.INSTANCE;
         }
 
-        if (rootCA != null) {
-            return TrustSelfSignedStrategy.INSTANCE;
-        }
-
+        // When a Root CA is configured it is loaded into the truststore (see makeHttpClient) and used
+        // as the trust anchor for standard PKIX path validation. We intentionally return null (no custom
+        // TrustStrategy) so the keystore-backed trust manager actually verifies the controller certificate
+        // against the configured Root CA. Returning TrustSelfSignedStrategy here would trust ANY
+        // single-certificate chain and silently bypass the configured Root CA for self-signed controllers.
         return null;
+    }
+
+    private void logTlsTrustPosture() {
+        if (skipTLSVerification) {
+            AnkaMgmtCloud.Log("%s: TLS verification DISABLED (Skip TLS Verification is on). "
+                            + "The controller certificate is NOT validated; this is insecure and intended for testing only.",
+                    AnkaSdkLog.cloudLabel(cloudName));
+        } else if (rootCA != null) {
+            AnkaMgmtCloud.Log("%s: TLS verification enabled - validating the controller certificate "
+                            + "against the configured Root CA via standard PKIX path validation.",
+                    AnkaSdkLog.cloudLabel(cloudName));
+        } else {
+            AnkaMgmtCloud.Log("%s: TLS verification enabled - validating the controller certificate "
+                            + "against the JVM default trust store (no Root CA configured).",
+                    AnkaSdkLog.cloudLabel(cloudName));
+        }
     }
 
     protected HttpRequestBase setBody(HttpEntityEnclosingRequestBase request, JSONObject requestBody) throws UnsupportedEncodingException {

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaMgmtCommunicator.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaMgmtCommunicator.java
@@ -134,6 +134,16 @@ public class AnkaMgmtCommunicator {
         this.cloudName = cloudName;
     }
 
+    protected boolean controllerUsesHttps() {
+        if (mgmtUrl != null) {
+            return "https".equalsIgnoreCase(mgmtUrl.getProtocol());
+        }
+        if (roundRobin != null) {
+            return roundRobin.anyEndpointUsesHttps();
+        }
+        return false;
+    }
+
     protected void logException(Throwable exception) {
         if (apiAuthLogContext != null && !apiAuthLogContext.isEmpty()) {
             AnkaMgmtCloud.Log(
@@ -727,7 +737,7 @@ public class AnkaMgmtCommunicator {
         RequestConfig defaultRequestConfig = makeRequestConfig(timeout, null);
         HttpClientBuilder builder = HttpClientBuilder.create();
         KeyStore keystore = this.getKeyStore();
-        if (rootCA != null) {
+        if (controllerUsesHttps() && rootCA != null && !rootCA.isBlank()) {
             if (keystore == null) {
                 keystore = KeyStore.getInstance("JKS");
                 keystore.load(null);
@@ -735,7 +745,9 @@ public class AnkaMgmtCommunicator {
             Certificate certificate = RootCaCertificateParser.parsePemToCertificate(rootCA);
             keystore.setCertificateEntry("rootCA", certificate);
         }
-        logTlsTrustPosture();
+        if (controllerUsesHttps()) {
+            logTlsTrustPosture();
+        }
 
         SSLContext sslContext = this.getSSLContext(keystore);
         PoolingHttpClientConnectionManager cm = getConnectionManager(sslContext);
@@ -795,7 +807,7 @@ public class AnkaMgmtCommunicator {
             AnkaMgmtCloud.Log("%s: TLS verification DISABLED (Skip TLS Verification is on). "
                             + "The controller certificate is NOT validated; this is insecure and intended for testing only.",
                     AnkaSdkLog.cloudLabel(cloudName));
-        } else if (rootCA != null) {
+        } else if (rootCA != null && !rootCA.isBlank()) {
             AnkaMgmtCloud.Log("%s: TLS verification enabled - validating the controller certificate "
                             + "against the configured Root CA via standard PKIX path validation.",
                     AnkaSdkLog.cloudLabel(cloudName));

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaMgmtUakCommunicator.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaMgmtUakCommunicator.java
@@ -17,6 +17,12 @@ public class AnkaMgmtUakCommunicator extends AnkaMgmtCommunicator {
     }
 
     @Override
+    public void setCloudName(String cloudName) {
+        super.setCloudName(cloudName);
+        this.authenticator.setCloudName(cloudName);
+    }
+
+    @Override
     protected void addHeaders(HttpRequestBase request) throws AnkaMgmtException, ClientException {
         NameValuePair authHeader = this.authenticator.getAuthorization();
         request.setHeader(authHeader.getName(), authHeader.getValue());

--- a/src/main/java/com/veertu/ankaMgmtSdk/AnkaSdkLog.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/AnkaSdkLog.java
@@ -12,4 +12,11 @@ final class AnkaSdkLog {
         }
         return PREFIX + message;
     }
+
+    static String cloudLabel(String cloudName) {
+        if (cloudName != null && !cloudName.isEmpty()) {
+            return String.format("Anka cloud '%s'", cloudName);
+        }
+        return "Anka cloud (unnamed)";
+    }
 }

--- a/src/main/java/com/veertu/ankaMgmtSdk/RootCaCertificateParser.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/RootCaCertificateParser.java
@@ -15,6 +15,8 @@ import java.security.cert.CertificateException;
  * with a clear {@link CertificateException} instead of failing later with a {@link NullPointerException}.
  */
 final class RootCaCertificateParser {
+    private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
 
     private RootCaCertificateParser() {}
 
@@ -27,7 +29,7 @@ final class RootCaCertificateParser {
             throw new CertificateException("Root CA PEM is empty");
         }
 
-        try (PEMParser reader = new PEMParser(new StringReader(trimmed))) {
+        try (PEMParser reader = new PEMParser(new StringReader(normalizeCertificatePem(trimmed)))) {
             final Object parsed;
             try {
                 parsed = reader.readObject();
@@ -56,5 +58,27 @@ final class RootCaCertificateParser {
                 throw new CertificateException("Root CA PEM is not a valid X.509 certificate", e);
             }
         }
+    }
+
+    private static String normalizeCertificatePem(String pem) throws CertificateException {
+        int begin = pem.indexOf(BEGIN_CERTIFICATE);
+        if (begin < 0) {
+            return pem;
+        }
+
+        int payloadStart = begin + BEGIN_CERTIFICATE.length();
+        int end = pem.indexOf(END_CERTIFICATE, payloadStart);
+        if (end < 0) {
+            throw new CertificateException("Root CA PEM is missing " + END_CERTIFICATE);
+        }
+
+        String prefix = pem.substring(0, begin);
+        String suffix = pem.substring(end + END_CERTIFICATE.length());
+        if (!prefix.trim().isEmpty() || !suffix.trim().isEmpty()) {
+            throw new CertificateException("Root CA PEM must contain exactly one certificate block");
+        }
+
+        String encodedCertificate = pem.substring(payloadStart, end).replaceAll("\\s+", "");
+        return BEGIN_CERTIFICATE + "\n" + encodedCertificate + "\n" + END_CERTIFICATE;
     }
 }

--- a/src/main/java/com/veertu/ankaMgmtSdk/RootCaCertificateParser.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/RootCaCertificateParser.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,6 +24,8 @@ import java.util.regex.Pattern;
  * (certificate bundles, PEMs surrounded by OpenSSL metadata, etc.) are therefore never rejected.
  */
 final class RootCaCertificateParser {
+
+    private static final Logger LOGGER = Logger.getLogger(RootCaCertificateParser.class.getName());
 
     /** Matches a single PEM block, capturing the label (group 1) and the base64 body (group 2). */
     private static final Pattern PEM_BLOCK = Pattern.compile(
@@ -49,8 +52,14 @@ final class RootCaCertificateParser {
             if (repaired == null) {
                 throw originalFailure;
             }
+            LOGGER.info(AnkaSdkLog.prefix(String.format(
+                    "Root CA PEM could not be parsed as stored (%s); attempting repair for whitespace-flattened certificate block",
+                    originalFailure.getMessage())));
             try {
-                return readCertificate(repaired);
+                Certificate certificate = readCertificate(repaired);
+                LOGGER.warning(AnkaSdkLog.prefix(
+                        "Root CA PEM parsed successfully after repairing whitespace-flattened certificate block"));
+                return certificate;
             } catch (CertificateException repairDidNotHelp) {
                 // Surface the original failure so the message reflects exactly what the user provided.
                 throw originalFailure;

--- a/src/main/java/com/veertu/ankaMgmtSdk/RootCaCertificateParser.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/RootCaCertificateParser.java
@@ -9,14 +9,27 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Parses a controller Root CA from PEM text. Rejects empty, non-PEM, or non-certificate content
  * with a clear {@link CertificateException} instead of failing later with a {@link NullPointerException}.
+ *
+ * <p>Some credential stores (notably the Jenkins "Secret text" single-line field) collapse the
+ * newlines of a pasted PEM into spaces, which {@link PEMParser} cannot decode. To stay backward
+ * compatible the PEM is first parsed exactly as provided; only when that fails do we attempt to
+ * repair whitespace-flattened blocks and retry. Inputs that parsed before this repair existed
+ * (certificate bundles, PEMs surrounded by OpenSSL metadata, etc.) are therefore never rejected.
  */
 final class RootCaCertificateParser {
-    private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
-    private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
+
+    /** Matches a single PEM block, capturing the label (group 1) and the base64 body (group 2). */
+    private static final Pattern PEM_BLOCK = Pattern.compile(
+            "-----BEGIN ([A-Z0-9 ]+?)-----(.*?)-----END \\1-----",
+            Pattern.DOTALL);
+
+    private static final int PEM_LINE_LENGTH = 64;
 
     private RootCaCertificateParser() {}
 
@@ -29,7 +42,24 @@ final class RootCaCertificateParser {
             throw new CertificateException("Root CA PEM is empty");
         }
 
-        try (PEMParser reader = new PEMParser(new StringReader(normalizeCertificatePem(trimmed)))) {
+        try {
+            return readCertificate(trimmed);
+        } catch (CertificateException originalFailure) {
+            String repaired = repairFlattenedPem(trimmed);
+            if (repaired == null) {
+                throw originalFailure;
+            }
+            try {
+                return readCertificate(repaired);
+            } catch (CertificateException repairDidNotHelp) {
+                // Surface the original failure so the message reflects exactly what the user provided.
+                throw originalFailure;
+            }
+        }
+    }
+
+    private static Certificate readCertificate(String pem) throws CertificateException, IOException {
+        try (PEMParser reader = new PEMParser(new StringReader(pem))) {
             final Object parsed;
             try {
                 parsed = reader.readObject();
@@ -60,25 +90,28 @@ final class RootCaCertificateParser {
         }
     }
 
-    private static String normalizeCertificatePem(String pem) throws CertificateException {
-        int begin = pem.indexOf(BEGIN_CERTIFICATE);
-        if (begin < 0) {
-            return pem;
+    /**
+     * Rebuilds any PEM blocks whose base64 body had its line breaks collapsed (e.g. into spaces) so
+     * {@link PEMParser} can decode them. Returns {@code null} when no PEM block is present, signalling
+     * that no repair is possible and the original parse failure should stand.
+     */
+    private static String repairFlattenedPem(String pem) {
+        Matcher matcher = PEM_BLOCK.matcher(pem);
+        StringBuilder rebuilt = new StringBuilder();
+        boolean foundBlock = false;
+        while (matcher.find()) {
+            String label = matcher.group(1);
+            String body = matcher.group(2).replaceAll("\\s+", "");
+            if (body.isEmpty()) {
+                continue;
+            }
+            foundBlock = true;
+            rebuilt.append("-----BEGIN ").append(label).append("-----\n");
+            for (int i = 0; i < body.length(); i += PEM_LINE_LENGTH) {
+                rebuilt.append(body, i, Math.min(i + PEM_LINE_LENGTH, body.length())).append('\n');
+            }
+            rebuilt.append("-----END ").append(label).append("-----\n");
         }
-
-        int payloadStart = begin + BEGIN_CERTIFICATE.length();
-        int end = pem.indexOf(END_CERTIFICATE, payloadStart);
-        if (end < 0) {
-            throw new CertificateException("Root CA PEM is missing " + END_CERTIFICATE);
-        }
-
-        String prefix = pem.substring(0, begin);
-        String suffix = pem.substring(end + END_CERTIFICATE.length());
-        if (!prefix.trim().isEmpty() || !suffix.trim().isEmpty()) {
-            throw new CertificateException("Root CA PEM must contain exactly one certificate block");
-        }
-
-        String encodedCertificate = pem.substring(payloadStart, end).replaceAll("\\s+", "");
-        return BEGIN_CERTIFICATE + "\n" + encodedCertificate + "\n" + END_CERTIFICATE;
+        return foundBlock ? rebuilt.toString() : null;
     }
 }

--- a/src/main/java/com/veertu/ankaMgmtSdk/UakAuthenticator.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/UakAuthenticator.java
@@ -54,6 +54,15 @@ public class UakAuthenticator {
         this.cloudName = cloudName;
     }
 
+    private boolean controllerUsesHttps() {
+        for (String mgmtURL : mgmtURLs) {
+            if (mgmtURL != null && mgmtURL.regionMatches(true, 0, "https://", 0, 8)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Parses a UAK credential string and returns the RSA private key.
      * UAK can be either a PEM formatted private key or just a concatenated string without header and footer.
@@ -250,26 +259,32 @@ public class UakAuthenticator {
      */
     private CloseableHttpClient createHttpClient(boolean skipTLSVerification, String rootCA) throws Exception {
         SSLConnectionSocketFactory sslSocketFactory;
+        boolean usesHttps = controllerUsesHttps();
 
         if (skipTLSVerification) {
-            AnkaMgmtCloud.Log("%s: UAK auth: TLS verification DISABLED (Skip TLS Verification is on). "
-                    + "The controller certificate is NOT validated; this is insecure and intended for testing only.",
-                    AnkaSdkLog.cloudLabel(cloudName));
+            if (usesHttps) {
+                AnkaMgmtCloud.Log("%s: UAK auth: TLS verification DISABLED (Skip TLS Verification is on). "
+                        + "The controller certificate is NOT validated; this is insecure and intended for testing only.",
+                        AnkaSdkLog.cloudLabel(cloudName));
+            }
             SSLContext sslContext = SSLContexts.custom()
                     .loadTrustMaterial(null, TrustAllStrategy.INSTANCE)
                     .build();
             sslSocketFactory = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
 
-        } else if (rootCA != null && !rootCA.isEmpty()) {
+        } else if (usesHttps && rootCA != null && !rootCA.isEmpty()) {
             AnkaMgmtCloud.Log("%s: UAK auth: validating the controller certificate against the configured Root CA "
                     + "via standard PKIX path validation.",
                     AnkaSdkLog.cloudLabel(cloudName));
             sslSocketFactory = createCustomSSLSocketFactory(rootCA);
 
-        } else {
+        } else if (usesHttps) {
             AnkaMgmtCloud.Log("%s: UAK auth: validating the controller certificate against the JVM default trust store "
                     + "(no Root CA configured).",
                     AnkaSdkLog.cloudLabel(cloudName));
+            sslSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
+
+        } else {
             sslSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
         }
 

--- a/src/main/java/com/veertu/ankaMgmtSdk/UakAuthenticator.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/UakAuthenticator.java
@@ -213,6 +213,7 @@ public class UakAuthenticator {
      */
     private String postRequest(String endpoint, String jsonData) throws ClientException {
         int retries = 1;
+        Exception lastFailure = null;
         retryLoop:
         while (retries <= maxRetries && mgmtURLs.size() == 1) { // Only retry if there is a single endpoint
             for (String mgmtURL : mgmtURLs) {
@@ -240,12 +241,16 @@ public class UakAuthenticator {
                 } catch (Exception e) {
                     AnkaMgmtCloud.Log(AnkaSdkLog.cloudLabel(cloudName) + ": Failed to send request to: " + endpoint
                             + " - " + e.getMessage());
+                    lastFailure = e;
                 }
             }
 
             retries++;
         }
 
+        if (lastFailure != null) {
+            throw new ClientException(lastFailure);
+        }
         throw new ClientException("Failed to send request to any of the endpoints");
     }
 

--- a/src/main/java/com/veertu/ankaMgmtSdk/UakAuthenticator.java
+++ b/src/main/java/com/veertu/ankaMgmtSdk/UakAuthenticator.java
@@ -14,7 +14,6 @@ import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
-import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -49,6 +48,11 @@ public class UakAuthenticator {
     private final String rootCA;
     private final String id;
     private PrivateKey key;
+    private String cloudName;
+
+    public void setCloudName(String cloudName) {
+        this.cloudName = cloudName;
+    }
 
     /**
      * Parses a UAK credential string and returns the RSA private key.
@@ -217,14 +221,16 @@ public class UakAuthenticator {
                             return responseText;
                         }
 
-                        AnkaMgmtCloud.Log("POST request to " + endpoint + " failed: " + statusCode + " - " + responseText);
+                        AnkaMgmtCloud.Log(AnkaSdkLog.cloudLabel(cloudName) + ": POST request to " + endpoint
+                                + " failed: " + statusCode + " - " + responseText);
 
                         if (statusCode >= 400 && statusCode < 500) {
                             break retryLoop;
                         }
                     }
                 } catch (Exception e) {
-                    AnkaMgmtCloud.Log("Failed to send request to: " + endpoint + " - " + e.getMessage());
+                    AnkaMgmtCloud.Log(AnkaSdkLog.cloudLabel(cloudName) + ": Failed to send request to: " + endpoint
+                            + " - " + e.getMessage());
                 }
             }
 
@@ -246,15 +252,24 @@ public class UakAuthenticator {
         SSLConnectionSocketFactory sslSocketFactory;
 
         if (skipTLSVerification) {
+            AnkaMgmtCloud.Log("%s: UAK auth: TLS verification DISABLED (Skip TLS Verification is on). "
+                    + "The controller certificate is NOT validated; this is insecure and intended for testing only.",
+                    AnkaSdkLog.cloudLabel(cloudName));
             SSLContext sslContext = SSLContexts.custom()
                     .loadTrustMaterial(null, TrustAllStrategy.INSTANCE)
                     .build();
             sslSocketFactory = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
 
         } else if (rootCA != null && !rootCA.isEmpty()) {
+            AnkaMgmtCloud.Log("%s: UAK auth: validating the controller certificate against the configured Root CA "
+                    + "via standard PKIX path validation.",
+                    AnkaSdkLog.cloudLabel(cloudName));
             sslSocketFactory = createCustomSSLSocketFactory(rootCA);
 
         } else {
+            AnkaMgmtCloud.Log("%s: UAK auth: validating the controller certificate against the JVM default trust store "
+                    + "(no Root CA configured).",
+                    AnkaSdkLog.cloudLabel(cloudName));
             sslSocketFactory = SSLConnectionSocketFactory.getSocketFactory();
         }
 
@@ -281,9 +296,12 @@ public class UakAuthenticator {
         keyStore.load(null);
         keyStore.setCertificateEntry("rootCA", certificate);
 
-
+        // Validate the controller certificate against the configured Root CA using standard PKIX.
+        // Passing a null TrustStrategy (instead of TrustSelfSignedStrategy) keeps the keystore-backed
+        // trust manager in effect; TrustSelfSignedStrategy would trust ANY single-certificate chain and
+        // bypass the configured Root CA for self-signed controller certificates.
         SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial(keyStore, new TrustSelfSignedStrategy())
+                .loadTrustMaterial(keyStore, null)
                 .build();
 
         return new SSLConnectionSocketFactory(sslContext);

--- a/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
+++ b/src/main/java/com/veertu/plugin/anka/AnkaMgmtCloud.java
@@ -382,6 +382,7 @@ public class AnkaMgmtCloud extends Cloud {
         ankaAPI.setMaxConnections(maxConnections);
         ankaAPI.setConnectionKeepAliveSeconds(connectionKeepAliveSeconds);
         ankaAPI.setApiAuthLogContext(describeCredential(credentials, credentialsId));
+        ankaAPI.setCloudName(getCloudName());
     }
 
     static String describeCredential(Credentials credentials, String credentialsId) {

--- a/src/test/java/com/veertu/ankaMgmtSdk/RootCaCertificateParserTest.java
+++ b/src/test/java/com/veertu/ankaMgmtSdk/RootCaCertificateParserTest.java
@@ -27,6 +27,28 @@ public class RootCaCertificateParserTest {
             -----END CERTIFICATE-----
             """;
 
+    private static final String SECOND_CERTIFICATE = """
+            -----BEGIN CERTIFICATE-----
+            MIIDJzCCAg+gAwIBAgIUHdi0mjZCogldRA9wblQa29ipuMYwDQYJKoZIhvcNAQEL
+            BQAwIzEhMB8GA1UEAwwYQW5rYSBSb290IENBIFBhcnNlciBUZXN0MB4XDTI2MDYx
+            MjE0MjAwOVoXDTM2MDYwOTE0MjAwOVowIzEhMB8GA1UEAwwYQW5rYSBSb290IENB
+            IFBhcnNlciBUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqnpf
+            Q1O7kN9kcOLlS7GYHoKMcNrog1scCmaYRcsTLcpiqNhbe46q/S7cKC0Jef/kcHP1
+            r9lhwyNgemKn462wMws9tJok7D8Lf+6ICNXQzbbv4p2BiNiQb6BGhs3mVnM1FS4m
+            pFpQEFEOLHhE/II5cAR2Ct6mY3EXQKRyt+m8AUxt6l5Ye8EuiDWTmc00lWCrWIg4
+            SIPFIHTzz6bEYcPJYOtRPhQTUsl6kboGzEWY/967aMn6mUgioIl+n7QC9WyhvMep
+            hmtV935gtiDTt18hURgTB7N5qxMZRGW/XcZ6iasFA+Eq+juPFf9BdecD2Nnr3h0w
+            ipS7a+S4ivQk9EF1LwIDAQABo1MwUTAdBgNVHQ4EFgQUv2hcL2t2z2H7fJLLq96n
+            mjQBc5IwHwYDVR0jBBgwFoAUv2hcL2t2z2H7fJLLq96nmjQBc5IwDwYDVR0TAQH/
+            BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAb4wG4EHfO+uhFKilqKI5v2Cpaob1
+            kV/Dn3SRzZa90ZxZzVedPH/2Or+uFRrPqFddp0m/HySsZ/1JpMFlznr7TgWyAzff
+            +pwqPvG/UQLULyazuNj4unVJfhO8u2luXOxs0yk73oh0L9Bo1ElqBLeWy4TLoxxK
+            dRvSj1J0lJ59u7wkP9Q6Wo+Euxz0XlqMNrCjeXKBHouQPM+x/1o7yk0cAc+sU6G9
+            k4cdttFWV1Kun9PLI/2n3qgQT2VdsW26km6+3OYDw/5w97QI6XEMm3yxNQliJP5Y
+            3TEI6HNBplSFlB+RoZG8mcGHT1pz+JwIdkKJ+nosKOGvTIGMJ9eyHI4Qkw==
+            -----END CERTIFICATE-----
+            """;
+
     @Test
     public void parsePemToCertificate_acceptsMultilinePem() throws Exception {
         assertNotNull(RootCaCertificateParser.parsePemToCertificate(VALID_CERTIFICATE));
@@ -39,11 +61,18 @@ public class RootCaCertificateParserTest {
     }
 
     @Test
-    public void parsePemToCertificate_rejectsTextOutsideCertificateBlock() {
-        CertificateException ex = assertThrows(
-                CertificateException.class,
-                () -> RootCaCertificateParser.parsePemToCertificate("unexpected " + VALID_CERTIFICATE));
-        assertThat(ex.getMessage(), containsString("exactly one certificate block"));
+    public void parsePemToCertificate_acceptsCertificateBundle() throws Exception {
+        assertNotNull(RootCaCertificateParser.parsePemToCertificate(
+                VALID_CERTIFICATE + SECOND_CERTIFICATE));
+    }
+
+    @Test
+    public void parsePemToCertificate_acceptsPemWithSurroundingMetadata() throws Exception {
+        String withMetadata = "subject=/CN=Anka Root CA Parser Test\n"
+                + "issuer=/CN=Anka Root CA Parser Test\n"
+                + VALID_CERTIFICATE
+                + "\ntrailing metadata that openssl x509 -text may append\n";
+        assertNotNull(RootCaCertificateParser.parsePemToCertificate(withMetadata));
     }
 
     @Test

--- a/src/test/java/com/veertu/ankaMgmtSdk/RootCaCertificateParserTest.java
+++ b/src/test/java/com/veertu/ankaMgmtSdk/RootCaCertificateParserTest.java
@@ -6,9 +6,45 @@ import java.security.cert.CertificateException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 public class RootCaCertificateParserTest {
+    private static final String VALID_CERTIFICATE = """
+            -----BEGIN CERTIFICATE-----
+            MIICIjCCAYugAwIBAgIUHLdi0rDaq6sxT0Ma31TzyyiSTUIwDQYJKoZIhvcNAQEL
+            BQAwIzEhMB8GA1UEAwwYQW5rYSBSb290IENBIFBhcnNlciBUZXN0MB4XDTI2MDYx
+            MjA5NDMwOVoXDTI2MDYxMzA5NDMwOVowIzEhMB8GA1UEAwwYQW5rYSBSb290IENB
+            IFBhcnNlciBUZXN0MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDNIRg8PRth
+            PzrEbfyZVZsmu0gR54ZnUuiEOpQgvTSzdp/cSwlDrKqUZgT028WfhHJEQ3LHPkOH
+            9tA4tXrhTPndEW3dRei8uLXRyZ4l7kPfY2HHxpNzxP7Mz+KRUs+DcTpQ09vA5lRr
+            h3V6cBRHOUXrfvOAKf46I+EsHAzZLptkNwIDAQABo1MwUTAdBgNVHQ4EFgQUc4cH
+            mY3ynStmdp3N+hZmfNQIiMEwHwYDVR0jBBgwFoAUc4cHmY3ynStmdp3N+hZmfNQI
+            iMEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOBgQBxAyVjGu3RXpsC
+            mt85wd94TeeiCtcIyv0P1Pv7vYdwJ3KQyWolowJuhjUMmzOyH/6KxL58GqHIxCbx
+            1SaM/4eOC2vy+95F7fc8lYW6d85D97KLK96PILYAveo8UjWfjZSaP1eX1xnCsHyS
+            eADezoB6Qtc4k2qKCXmv65EMFuYO9g==
+            -----END CERTIFICATE-----
+            """;
+
+    @Test
+    public void parsePemToCertificate_acceptsMultilinePem() throws Exception {
+        assertNotNull(RootCaCertificateParser.parsePemToCertificate(VALID_CERTIFICATE));
+    }
+
+    @Test
+    public void parsePemToCertificate_acceptsSpaceFlattenedPem() throws Exception {
+        assertNotNull(RootCaCertificateParser.parsePemToCertificate(
+                VALID_CERTIFICATE.replaceAll("\\R", " ")));
+    }
+
+    @Test
+    public void parsePemToCertificate_rejectsTextOutsideCertificateBlock() {
+        CertificateException ex = assertThrows(
+                CertificateException.class,
+                () -> RootCaCertificateParser.parsePemToCertificate("unexpected " + VALID_CERTIFICATE));
+        assertThat(ex.getMessage(), containsString("exactly one certificate block"));
+    }
 
     @Test
     public void parsePemToCertificate_rejectsNonPemText() {


### PR DESCRIPTION
- [fix: Secret Text UI using a single-line replaces pasted PEM newlines with spaces](https://github.com/jenkinsci/anka-build-plugin/pull/65)
- Fixed bug that allowed any Root CA (even ones that aren't for the controller) to validate and let the Jenkins plugin communicate with the Controller https. Now the Root CA must match the cert the https/TLS is using.
- New required oldest version of Jenkins: 2.504.1